### PR TITLE
feat: vendor PatternFly page styling

### DIFF
--- a/build.js
+++ b/build.js
@@ -263,6 +263,7 @@ if (args.watch) {
     };
 
     watch_dirs('src', on_change);
+    watch_dirs('vendor', on_change);
 
     await new Promise(() => {});
 }

--- a/vendor/cockpit-page.scss
+++ b/vendor/cockpit-page.scss
@@ -1,7 +1,7 @@
 /*
  * This file is part of Cockpit.
  *
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Cockpit is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
@@ -17,13 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import "../vendor/cockpit-page.scss";
+@use "@patternfly/patternfly/base";
 
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import { Application } from './app.jsx';
-import './app.scss';
-
-document.addEventListener("DOMContentLoaded", () => {
-    createRoot(document.getElementById("app")).render(<Application />);
-});
+@import "./patternfly-5-overrides.scss";

--- a/vendor/patternfly-5-overrides.scss
+++ b/vendor/patternfly-5-overrides.scss
@@ -1,7 +1,7 @@
 /*
  * This file is part of Cockpit.
  *
- * Copyright (C) 2017 Red Hat, Inc.
+ * Copyright (C) 2024 Red Hat, Inc.
  *
  * Cockpit is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
@@ -17,13 +17,4 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import "../vendor/cockpit-page.scss";
-
-import React from 'react';
-import { createRoot } from 'react-dom/client';
-import { Application } from './app.jsx';
-import './app.scss';
-
-document.addEventListener("DOMContentLoaded", () => {
-    createRoot(document.getElementById("app")).render(<Application />);
-});
+// PatternFly 5 overrides specific to Cockpit sensors UI can be added here.


### PR DESCRIPTION
## Summary
- add a vendor directory with PatternFly base and override styles for Cockpit sensors
- load the vendored styles from the application entry point
- watch the vendor directory in esbuild so vendored Sass changes are rebuilt

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68df70ab89048328b02e22f2084bb568