### PR TITLE
feat: scaffold sensor data flow

### DIFF
--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import cockpit from 'cockpit';
+
+import { Reading, SensorChipGroup } from '../types/sensors';
+
+const _ = cockpit.gettext;
+
+export interface SensorTableProps {
+    groups: SensorChipGroup[];
+}
+
+interface TableRow {
+    key: string;
+    chip: string;
+    reading: Reading;
+}
+
+const MISSING_VALUE = '—';
+
+const formatValue = (value: number | undefined, unit?: string) => {
+    if (typeof value !== 'number') {
+        return MISSING_VALUE;
+    }
+
+    const formatter = new Intl.NumberFormat(undefined, {
+        maximumFractionDigits: Math.abs(value) < 10 ? 2 : 1,
+        minimumFractionDigits: 0,
+    });
+
+    const formatted = formatter.format(value);
+    return unit ? `${formatted} ${unit}` : formatted;
+};
+
+export const SensorTable: React.FC<SensorTableProps> = ({ groups }) => {
+    const rows = React.useMemo<TableRow[]>(
+        () =>
+            groups.flatMap(group =>
+                group.readings.map((reading, index) => ({
+                    key: `${group.id}-${index}`,
+                    chip: group.label,
+                    reading,
+                })),
+            ),
+        [groups],
+    );
+
+    return (
+        <div className="pf-c-table-wrapper" data-component="sensor-table">
+            <table className="pf-c-table pf-m-compact pf-m-grid-md" role="grid" aria-label={_('Sensor readings')}>
+                <thead>
+                    <tr>
+                        <th scope="col">{_('Chip')}</th>
+                        <th scope="col">{_('Sensor')}</th>
+                        <th scope="col">{_('Input')}</th>
+                        <th scope="col">{_('Minimum')}</th>
+                        <th scope="col">{_('Maximum')}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.length === 0 ? (
+                        <tr>
+                            <td colSpan={5}>{_('No sensor data available yet.')}</td>
+                        </tr>
+                    ) : (
+                        rows.map(row => {
+                            const { reading } = row;
+                            const exceedsMax = typeof reading.max === 'number' && reading.input > reading.max;
+                            const rowClassName = exceedsMax ? 'pf-m-danger' : undefined;
+
+                            return (
+                                <tr key={row.key} className={rowClassName}>
+                                    <td data-label={_('Chip')}>{row.chip}</td>
+                                    <td data-label={_('Sensor')}>{reading.label}</td>
+                                    <td data-label={_('Input')}>{formatValue(reading.input, reading.unit)}</td>
+                                    <td data-label={_('Minimum')}>{formatValue(reading.min, reading.unit)}</td>
+                                    <td data-label={_('Maximum')}>{formatValue(reading.max, reading.unit)}</td>
+                                </tr>
+                            );
+                        })
+                    )}
+                </tbody>
+            </table>
+        </div>
+    );
+};

--- a/src/hooks/useSensors.ts
+++ b/src/hooks/useSensors.ts
@@ -1,0 +1,155 @@
+import React from 'react';
+import { EMPTY_SENSOR_DATA, SensorCategory, SensorData } from '../types/sensors';
+import { parseSensorsJson } from '../utils/parseSensorsJson';
+
+const MOCK_REFRESH_INTERVAL_MS = 5000;
+
+interface UseSensorsResult {
+    data: SensorData;
+    isLoading: boolean;
+    isMocked: boolean;
+}
+
+type MockReading = {
+    label: string;
+    input: number;
+    min?: number;
+    max?: number;
+    critical?: number;
+    unit?: string;
+};
+
+type MockGroup = {
+    id: string;
+    name: string;
+    label: string;
+    category: SensorCategory;
+    readings: MockReading[];
+};
+
+const BASE_MOCK_GROUPS: MockGroup[] = [
+    {
+        id: 'chip-cpu-0',
+        name: 'k10temp-pci-00c3',
+        label: 'CPU package sensors',
+        category: 'temperature',
+        readings: [
+            { label: 'Tctl', input: 48.5, max: 90, critical: 95, unit: '°C' },
+            { label: 'Tdie', input: 47.2, max: 90, critical: 95, unit: '°C' },
+        ],
+    },
+    {
+        id: 'chip-fan-0',
+        name: 'nct6796d-isa-0290',
+        label: 'Chassis fans',
+        category: 'fan',
+        readings: [
+            { label: 'Chassis fan 1', input: 1180, min: 600, max: 2100, unit: 'RPM' },
+            { label: 'Chassis fan 2', input: 1320, min: 600, max: 2200, unit: 'RPM' },
+        ],
+    },
+    {
+        id: 'chip-voltage-0',
+        name: 'nct6796d-isa-0290-voltage',
+        label: 'Voltage rails',
+        category: 'voltage',
+        readings: [
+            { label: '+12V', input: 12.2, min: 11.6, max: 12.6, unit: 'V' },
+            { label: '+5V', input: 5.02, min: 4.8, max: 5.2, unit: 'V' },
+        ],
+    },
+];
+
+const buildMockPayload = (step: number) => ({
+    timestamp: Date.now(),
+    chips: BASE_MOCK_GROUPS.map(group => ({
+        ...group,
+        readings: group.readings.map((reading, index) => {
+            const oscillation = Math.sin(step / 2 + index) * 1.5;
+            const input = reading.input + oscillation;
+            return {
+                ...reading,
+                input: input.toFixed(2),
+            };
+        }),
+    })),
+});
+
+const readImportMetaEnv = (): unknown => {
+    try {
+        // eslint-disable-next-line no-new-func
+        const getter = new Function(
+            'return typeof import.meta !== "undefined" ? import.meta : undefined;',
+        );
+        const meta = getter();
+        if (meta && typeof meta === 'object' && 'env' in meta) {
+            return (meta as { env?: Record<string, unknown> }).env?.VITE_MOCK;
+        }
+    } catch (error) {
+        // Ignore environments where dynamic evaluation is blocked.
+    }
+
+    return undefined;
+};
+
+const readMockFlag = (): string | undefined => {
+    const globalValue = (globalThis as Record<string, unknown>).VITE_MOCK;
+    if (typeof globalValue === 'string' || typeof globalValue === 'number') {
+        return String(globalValue);
+    }
+
+    const fromImportMeta = readImportMetaEnv();
+    if (typeof fromImportMeta === 'string' || typeof fromImportMeta === 'number') {
+        return String(fromImportMeta);
+    }
+
+    return undefined;
+};
+
+const useMockFlag = (): boolean => {
+    const [flag] = React.useState(() => {
+        const value = (readMockFlag() ?? '').toString().toLowerCase();
+        return value === '1' || value === 'true';
+    });
+
+    return flag;
+};
+
+export const useSensors = (): UseSensorsResult => {
+    const isMocked = useMockFlag();
+    const [data, setData] = React.useState<SensorData>(EMPTY_SENSOR_DATA);
+    const [isLoading, setIsLoading] = React.useState<boolean>(isMocked);
+
+    React.useEffect(() => {
+        if (!isMocked) {
+            setData({ ...EMPTY_SENSOR_DATA });
+            setIsLoading(false);
+            return undefined;
+        }
+
+        let cancelled = false;
+        let step = 0;
+
+        const pushUpdate = () => {
+            if (cancelled) {
+                return;
+            }
+
+            const payload = buildMockPayload(step);
+            step += 1;
+            const parsed = parseSensorsJson(payload);
+            setData(parsed);
+            setIsLoading(false);
+        };
+
+        pushUpdate();
+        const interval = window.setInterval(pushUpdate, MOCK_REFRESH_INTERVAL_MS);
+
+        return () => {
+            cancelled = true;
+            window.clearInterval(interval);
+        };
+    }, [isMocked]);
+
+    return { data, isLoading, isMocked };
+};

--- a/src/types/sensors.ts
+++ b/src/types/sensors.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared type definitions for sensor data displayed in the Cockpit Sensors UI.
+ *
+ * These interfaces intentionally focus on the subset of fields required by the
+ * frontend so that the UI code can remain implementation agnostic while the
+ * backend integration matures.
+ */
+
+/**
+ * High level categories that the UI presents via dedicated tabs.
+ */
+export type SensorCategory = 'temperature' | 'fan' | 'voltage' | 'power' | 'unknown';
+
+/**
+ * Normalised representation of a single sensor reading.
+ */
+export interface Reading {
+    /** Human readable sensor label shown in the table. */
+    label: string;
+    /** The current reading reported by the sensor. */
+    input: number;
+    /** Optional minimum value advertised by the sensor. */
+    min?: number;
+    /** Optional maximum value advertised by the sensor. */
+    max?: number;
+    /** Optional critical threshold reported by the sensor. */
+    critical?: number;
+    /** Optional engineering unit (°C, RPM, V, …). */
+    unit?: string;
+}
+
+/**
+ * Grouping of readings that belong to the same physical chip or virtual sensor.
+ */
+export interface SensorChipGroup {
+    /** Stable identifier that allows React to keep track of rendered rows. */
+    id: string;
+    /** Name reported by the backend (typically matches the lm-sensors chip name). */
+    name: string;
+    /** Localised label used in the UI. */
+    label: string;
+    /** Category used for tab based filtering in the UI. */
+    category: SensorCategory;
+    /** Individual sensor readings belonging to the chip. */
+    readings: Reading[];
+}
+
+/**
+ * Aggregated dataset returned by the sensors hook and parser.
+ */
+export interface SensorData {
+    /** Sensor readings grouped by chip. */
+    groups: SensorChipGroup[];
+    /** Optional timestamp reported by the backend (UNIX epoch milliseconds). */
+    timestamp?: number;
+}
+
+/**
+ * Convenience constant that represents the absence of sensor data.
+ */
+export const EMPTY_SENSOR_DATA: SensorData = { groups: [] };

--- a/src/utils/parseSensorsJson.ts
+++ b/src/utils/parseSensorsJson.ts
@@ -1,0 +1,151 @@
+import { EMPTY_SENSOR_DATA, Reading, SensorCategory, SensorChipGroup, SensorData } from '../types/sensors';
+
+type RawObject = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is RawObject =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isNonEmptyString = (value: unknown): value is string =>
+    typeof value === 'string' && value.trim().length > 0;
+
+const coerceNumber = (value: unknown): number | undefined => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : undefined;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed.length === 0) {
+            return undefined;
+        }
+
+        const parsed = Number.parseFloat(trimmed);
+        return Number.isFinite(parsed) ? parsed : undefined;
+    }
+
+    return undefined;
+};
+
+const parseCategory = (value: unknown): SensorCategory => {
+    if (typeof value !== 'string') {
+        return 'unknown';
+    }
+
+    switch (value.toLowerCase()) {
+        case 'temperature':
+        case 'fan':
+        case 'voltage':
+        case 'power':
+            return value.toLowerCase() as SensorCategory;
+        default:
+            return 'unknown';
+    }
+};
+
+const parseReading = (raw: unknown, fallbackLabel: string, index: number): Reading | null => {
+    if (!isRecord(raw)) {
+        return null;
+    }
+
+    const input = coerceNumber(raw.input);
+    if (typeof input !== 'number') {
+        return null;
+    }
+
+    const labelSource = isNonEmptyString(raw.label)
+        ? raw.label
+        : isNonEmptyString(raw.name)
+            ? raw.name
+            : undefined;
+
+    const reading: Reading = {
+        label: (labelSource ?? fallbackLabel).trim(),
+        input,
+    };
+
+    const min = coerceNumber(raw.min ?? raw.lower ?? raw.low);
+    if (typeof min === 'number') {
+        reading.min = min;
+    }
+
+    const max = coerceNumber(raw.max ?? raw.upper ?? raw.high);
+    if (typeof max === 'number') {
+        reading.max = max;
+    }
+
+    const critical = coerceNumber(raw.critical ?? raw.crit ?? raw['crit_max']);
+    if (typeof critical === 'number') {
+        reading.critical = critical;
+    }
+
+    if (isNonEmptyString(raw.unit)) {
+        reading.unit = raw.unit.trim();
+    }
+
+    return reading;
+};
+
+const parseGroup = (raw: unknown, index: number): SensorChipGroup | null => {
+    if (!isRecord(raw)) {
+        return null;
+    }
+
+    const id = isNonEmptyString(raw.id) ? raw.id.trim() : `chip-${index}`;
+    const name = isNonEmptyString(raw.name) ? raw.name.trim() : id;
+    const label = isNonEmptyString(raw.label) ? raw.label.trim() : name;
+    const category = parseCategory(raw.category);
+
+    const rawReadings = Array.isArray(raw.readings) ? raw.readings : Array.isArray(raw.values) ? raw.values : [];
+
+    const readings = rawReadings
+        .map((reading, readingIndex) => parseReading(reading, `${label} ${readingIndex + 1}`, readingIndex))
+        .filter((reading): reading is Reading => reading !== null);
+
+    if (readings.length === 0) {
+        return null;
+    }
+
+    return {
+        id,
+        name,
+        label,
+        category,
+        readings,
+    };
+};
+
+/**
+ * Normalises the raw JSON payload returned by the backend or by the mock layer.
+ *
+ * The function is intentionally pure to keep the data processing predictable and
+ * easy to test.
+ */
+export const parseSensorsJson = (raw: unknown): SensorData => {
+    if (!raw) {
+        return { ...EMPTY_SENSOR_DATA };
+    }
+
+    const container = isRecord(raw) ? raw : {};
+
+    const rawGroups = Array.isArray(raw)
+        ? raw
+        : Array.isArray(container.chips)
+            ? container.chips
+            : Array.isArray(container.groups)
+                ? container.groups
+                : [];
+
+    const groups = rawGroups
+        .map((group, index) => parseGroup(group, index))
+        .filter((group): group is SensorChipGroup => group !== null);
+
+    const timestamp = coerceNumber(container.timestamp ?? container.updated ?? container.time);
+
+    if (groups.length === 0) {
+        return timestamp ? { groups: [], timestamp } : { ...EMPTY_SENSOR_DATA };
+    }
+
+    return timestamp ? { groups, timestamp } : { groups };
+};
+
+export type { Reading, SensorChipGroup, SensorData };


### PR DESCRIPTION
## Summary
- add strongly typed sensor data model and normalization helper
- provide a sensors hook with mock data support and cleanup safe timers
- render a PatternFly styled sensor table and integrate it into the application tabs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df7c2092a88328b203ef32cde4c7d3