### PR TITLE
feat: display uncategorised sensors in a dedicated tab

### DIFF
--- a/src/__tests__/groups-for-category.test.ts
+++ b/src/__tests__/groups-for-category.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { groupsForCategory } from '../utils/grouping';
+import type { SensorChipGroup, SensorCategory } from '../types/sensors';
+
+const buildGroup = (id: string, category: SensorCategory): SensorChipGroup => ({
+    id,
+    name: id,
+    label: id,
+    category,
+    readings: [],
+});
+
+describe('groupsForCategory', () => {
+    it('returns only groups that belong to the requested category', () => {
+        const groups: SensorChipGroup[] = [
+            buildGroup('temp-1', 'temperature'),
+            buildGroup('unknown-1', 'unknown'),
+            buildGroup('fan-1', 'fan'),
+        ];
+
+        expect(groupsForCategory(groups, 'temperature')).toEqual([buildGroup('temp-1', 'temperature')]);
+        expect(groupsForCategory(groups, 'fan')).toEqual([buildGroup('fan-1', 'fan')]);
+        expect(groupsForCategory(groups, 'voltage')).toEqual([]);
+    });
+
+    it('only returns uncategorised groups for the dedicated tab', () => {
+        const groups: SensorChipGroup[] = [
+            buildGroup('unknown-1', 'unknown'),
+            buildGroup('unknown-2', 'unknown'),
+        ];
+
+        expect(groupsForCategory(groups, 'temperature')).toEqual([]);
+        expect(groupsForCategory(groups, 'unknown')).toEqual(groups);
+    });
+});

--- a/src/app/Application.tsx
+++ b/src/app/Application.tsx
@@ -32,6 +32,7 @@ import {
 import { SensorTable } from '../components/SensorTable';
 import { useSensors } from '../hooks/useSensors';
 import { SensorCategory } from '../types/sensors';
+import { groupsForCategory } from '../utils/grouping';
 
 import '../app.scss';
 
@@ -64,6 +65,14 @@ const TABS: readonly TabDefinition[] = [
         description: _('Review available voltage readings for power supplies and system buses.'),
         category: 'voltage',
     },
+    {
+        eventKey: 3,
+        title: _('Other sensors'),
+        description: _(
+            'Access readings for sensors that are not recognised as temperature, fan, or voltage devices.'
+        ),
+        category: 'unknown',
+    },
 ];
 
 export const Application: React.FC = () => {
@@ -86,20 +95,7 @@ export const Application: React.FC = () => {
     );
 
     const getGroupsForCategory = React.useCallback(
-        (category: SensorCategory) => {
-            const inCategory = data.groups.filter(group => group.category === category);
-            const uncategorised = data.groups.filter(group => group.category === 'unknown');
-
-            if (inCategory.length === 0) {
-                if (uncategorised.length > 0 && uncategorised.length === data.groups.length) {
-                    return uncategorised;
-                }
-
-                return [];
-            }
-
-            return uncategorised.length > 0 ? [...inCategory, ...uncategorised] : inCategory;
-        },
+        (category: SensorCategory) => groupsForCategory(data.groups, category),
         [data.groups],
     );
 

--- a/src/hooks/useSensors.ts
+++ b/src/hooks/useSensors.ts
@@ -66,6 +66,16 @@ const BASE_MOCK_GROUPS: MockGroup[] = [
             { label: '+5V', input: 5.02, min: 4.8, max: 5.2, unit: 'V' },
         ],
     },
+    {
+        id: 'chip-unknown-0',
+        name: 'nct6796d-isa-0290-other',
+        label: 'Auxiliary sensors',
+        category: 'unknown',
+        readings: [
+            { label: 'Intrusion detect', input: 0, unit: 'state' },
+            { label: 'VRM temperature', input: 42.1, unit: '°C' },
+        ],
+    },
 ];
 
 const buildMockPayload = (step: number) => ({

--- a/src/utils/grouping.ts
+++ b/src/utils/grouping.ts
@@ -1,0 +1,18 @@
+import type { SensorCategory, SensorChipGroup } from '../types/sensors';
+
+/**
+ * Return the chip groups that should be displayed for the provided sensor category.
+ *
+ * Unknown sensor groups are only returned when the dedicated "Other sensors" tab is queried,
+ * which prevents them from being duplicated across the individual category tabs.
+ */
+export const groupsForCategory = (
+    groups: SensorChipGroup[],
+    category: SensorCategory,
+): SensorChipGroup[] => {
+    if (category === 'unknown') {
+        return groups.filter(group => group.category === 'unknown');
+    }
+
+    return groups.filter(group => group.category === category);
+};


### PR DESCRIPTION
## Summary
- add an "Other sensors" tab and share category filtering logic to avoid duplicating uncategorised groups
- extend the mocked dataset so the UI and tests exercise sensors without a known category
- cover the new grouping helper with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0267e0f4883288caa05a4ce38eb59