### PR TITLE
fix: scope sensor description emphasis

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -1,5 +1,5 @@
 @use "page";
 
-p {
-    font-weight: bold;
+.sensor-description p {
+    font-weight: 600;
 }

--- a/src/app/Application.tsx
+++ b/src/app/Application.tsx
@@ -110,7 +110,7 @@ export const Application: React.FC = () => {
                 >
                     {TABS.map(tab => (
                         <Tab key={tab.eventKey} eventKey={tab.eventKey} title={<TabTitleText>{tab.title}</TabTitleText>}>
-                            <Content>
+                            <Content className="sensor-description">
                                 <h2>{tab.title}</h2>
                                 <p>{tab.description}</p>
                                 {!isMocked && !isLoading && (


### PR DESCRIPTION
## Summary
- scope the bold styling to sensor description paragraphs so general copy keeps the default weight
- attach the styling class to the tab content container that holds the emphasized description

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e06c6679808328af64aafe70d604ed