### PR TITLE
Switch cockpit page Sass overrides to @use

### DIFF
--- a/vendor/cockpit-page.scss
+++ b/vendor/cockpit-page.scss
@@ -19,4 +19,4 @@
 
 @use "@patternfly/patternfly/base";
 
-@import "./patternfly-5-overrides.scss";
+@use "./patternfly-5-overrides" as *;


### PR DESCRIPTION
## Summary
- replace the deprecated Sass @import with an equivalent @use for the PatternFly overrides

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e06ddcb9648328b229fc02882940fc