### PR TITLE
Surface power sensor groups in Other sensors tab

### DIFF
--- a/src/__tests__/groups-for-category.test.ts
+++ b/src/__tests__/groups-for-category.test.ts
@@ -33,4 +33,17 @@ describe('groupsForCategory', () => {
         expect(groupsForCategory(groups, 'temperature')).toEqual([]);
         expect(groupsForCategory(groups, 'unknown')).toEqual(groups);
     });
+
+    it('includes power groups in the fallback tab', () => {
+        const groups: SensorChipGroup[] = [
+            buildGroup('power-1', 'power'),
+            buildGroup('unknown-1', 'unknown'),
+            buildGroup('temp-1', 'temperature'),
+        ];
+
+        expect(groupsForCategory(groups, 'unknown')).toEqual([
+            buildGroup('power-1', 'power'),
+            buildGroup('unknown-1', 'unknown'),
+        ]);
+    });
 });

--- a/src/utils/grouping.ts
+++ b/src/utils/grouping.ts
@@ -5,13 +5,16 @@ import type { SensorCategory, SensorChipGroup } from '../types/sensors';
  *
  * Unknown sensor groups are only returned when the dedicated "Other sensors" tab is queried,
  * which prevents them from being duplicated across the individual category tabs.
+ *
+ * Power related sensors currently have no dedicated tab, so they are surfaced in the same
+ * catch-all list to ensure they remain visible to the user.
  */
 export const groupsForCategory = (
     groups: SensorChipGroup[],
     category: SensorCategory,
 ): SensorChipGroup[] => {
     if (category === 'unknown') {
-        return groups.filter(group => group.category === 'unknown');
+        return groups.filter(group => group.category === 'unknown' || group.category === 'power');
     }
 
     return groups.filter(group => group.category === category);


### PR DESCRIPTION
## Summary
- ensure power sensor groups are shown in the Other sensors view
- add a regression test covering the power category fallback for unknown tab

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e071169c9083289eafe6a65769ad6f