### PR TITLE
chore: rebuild after translation updates

### DIFF
--- a/build.js
+++ b/build.js
@@ -174,6 +174,7 @@ if (args.watch) {
 
     watch_dirs('src', on_change);
     watch_dirs('vendor', on_change);
+    watch_dirs('po', on_change);
 
     await new Promise(() => {});
 }


### PR DESCRIPTION
## Summary
- watch the translation directory during development builds so translation edits trigger rebuilds

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68e0754077d08328929b82b101e2a1ca