### PR TITLE
Include TypeScript sources in gettext extraction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,14 +49,14 @@ $(COCKPIT_REPO_STAMP): Makefile
 LINGUAS=$(basename $(notdir $(wildcard po/*.po)))
 
 po/$(PACKAGE_NAME).js.pot:
-	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ --language=C --keyword= \
+	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ --language=JavaScript --keyword= \
 		--add-comments=Translators: \
 		--keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \
-		--keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
-		--from-code=UTF-8 $$(find src/ -name '*.js' -o -name '*.jsx')
+                --keyword=gettextCatalog.getString:1,3c --keyword=gettextCatalog.getPlural:2,3,4c \
+                --from-code=UTF-8 $$(find src/ -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx' \))
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
 	pkg/lib/html2po.js -o $@ $$(find src -name '*.html')


### PR DESCRIPTION
## Summary
- update the gettext extraction rule to scan TS/TSX files and parse sources as JavaScript so TypeScript strings are included

## Testing
- make po/sensors.js.pot

------
https://chatgpt.com/codex/tasks/task_e_68e078f0de58832888c287ec8ce8e370