### PR TITLE
Fix: add translation loader for Cockpit extension

### DIFF
--- a/build-tools/translations.js
+++ b/build-tools/translations.js
@@ -9,6 +9,27 @@ const DEFAULT_WRAPPER = 'cockpit.locale(PO_DATA);';
 const RTL_LANGUAGES = new Set(['ar', 'fa', 'he', 'ur']);
 const PLURAL_EXPRESSION = /nplurals=[1-9]; plural=([^;]*);?$/;
 
+function canonicalizeLanguageCode(code) {
+    if (!code)
+        return null;
+
+    const normalized = code.replace(/-/g, '_');
+    const segments = normalized.split('_').filter(Boolean);
+    if (segments.length === 0)
+        return null;
+
+    const [base, ...rest] = segments;
+    const canonicalRest = rest.map(segment => {
+        if (segment.length === 2)
+            return segment.toUpperCase();
+        if (segment.length === 4)
+            return segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase();
+        return segment.toLowerCase();
+    });
+
+    return [base.toLowerCase(), ...canonicalRest].join('_');
+}
+
 function validatePluralForms(statement) {
     try {
         Jed.PF.parse(statement);
@@ -111,7 +132,9 @@ function createTranslationChunks({ parsed, subdir, srcDirectory, filter }) {
 
 async function buildTranslationFiles({ poPath, subdir, outdir, srcDirectory, wrapper }) {
     const parsed = await readPoFile(poPath);
-    const languageCode = path.basename(poPath).slice(0, -3);
+    const languageCode = canonicalizeLanguageCode(path.basename(poPath).slice(0, -3));
+    if (!languageCode)
+        throw new Error(`Unable to determine language code for ${poPath}`);
 
     const tasks = [
         { filename: `po.${languageCode}.js`, filter: ref => !ref.includes('manifest.json') },
@@ -126,12 +149,143 @@ async function buildTranslationFiles({ poPath, subdir, outdir, srcDirectory, wra
         const wrapperTemplate = typeof wrapper === 'function' ? wrapper(subdir) : DEFAULT_WRAPPER;
         await fs.writeFile(targetPath, wrapperTemplate.replace('PO_DATA', contents) + '\n');
     }));
+
+    return languageCode;
+}
+
+function createLoaderSource(languages) {
+    const sortedLanguages = Array.from(languages).sort((a, b) => a.localeCompare(b));
+    const languageLiteral = `[${sortedLanguages.map(code => JSON.stringify(code)).join(', ')}]`;
+
+    const lines = [
+        "'use strict';",
+        "(() => {",
+        `    const supportedLanguages = new Set(${languageLiteral});`,
+        "    if (supportedLanguages.size === 0)",
+        "        return;",
+        "",
+        "    function canonicalize(tag) {",
+        "        if (!tag)",
+        "            return null;",
+        "",
+        "        const normalized = tag.replace(/-/g, '_');",
+        "        const parts = normalized.split('_').filter(Boolean);",
+        "        if (parts.length === 0)",
+        "            return null;",
+        "",
+        "        const [base, ...rest] = parts;",
+        "        const formatted = rest.map(part => {",
+        "            if (part.length === 2)",
+        "                return part.toUpperCase();",
+        "            if (part.length === 4)",
+        "                return part.charAt(0).toUpperCase() + part.slice(1).toLowerCase();",
+        "            return part.toLowerCase();",
+        "        });",
+        "",
+        "        return [base.toLowerCase(), ...formatted].join('_');",
+        "    }",
+        "",
+        "    function pick(preferences) {",
+        "        for (const preference of preferences) {",
+        "            let candidate = canonicalize(preference);",
+        "            while (candidate) {",
+        "                if (supportedLanguages.has(candidate))",
+        "                    return candidate;",
+        "                const index = candidate.lastIndexOf('_');",
+        "                if (index === -1)",
+        "                    break;",
+        "                candidate = candidate.slice(0, index);",
+        "            }",
+        "        }",
+        "",
+        "        return null;",
+        "    }",
+        "",
+        "    const preferences = [];",
+        "    const seen = new Set();",
+        "",
+        "    function addPreference(value) {",
+        "        if (!value)",
+        "            return;",
+        "",
+        "        const trimmed = String(value).trim();",
+        "        if (!trimmed)",
+        "            return;",
+        "",
+        "        const key = trimmed.toLowerCase();",
+        "        if (seen.has(key))",
+        "            return;",
+        "",
+        "        seen.add(key);",
+        "        preferences.push(trimmed);",
+        "    }",
+        "",
+        "    if (window.cockpit && window.cockpit.language)",
+        "        addPreference(window.cockpit.language);",
+        "",
+        "    const nav = window.navigator;",
+        "    if (nav) {",
+        "        if (Array.isArray(nav.languages))",
+        "            for (const language of nav.languages)",
+        "                addPreference(language);",
+        "        addPreference(nav.language);",
+        "        addPreference(nav.userLanguage);",
+        "    }",
+        "",
+        "    if (document.documentElement && document.documentElement.lang)",
+        "        addPreference(document.documentElement.lang);",
+        "",
+        "    addPreference('en');",
+        "",
+        "    const selected = pick(preferences);",
+        "    if (!selected)",
+        "        return;",
+        "",
+        "    const current = document.currentScript;",
+        "    const script = document.createElement('script');",
+        "    script.type = 'text/javascript';",
+        "    script.async = false;",
+        "",
+        "    if (current) {",
+        "        const source = new URL('po.' + selected + '.js', current.src);",
+        "        script.src = source.toString();",
+        "        if (current.crossOrigin)",
+        "            script.crossOrigin = current.crossOrigin;",
+        "        if (current.parentNode)",
+        "            current.parentNode.insertBefore(script, current.nextSibling);",
+        "        else",
+        "            (document.head || document.documentElement).appendChild(script);",
+        "    } else {",
+        "        script.src = 'po.' + selected + '.js';",
+        "        (document.head || document.documentElement).appendChild(script);",
+        "    }",
+        "})();",
+        "",
+    ];
+
+    return lines.join('\n');
+}
+
+async function writeLoader({ outdir, subdir, languages }) {
+    const targetDir = subdir ? path.join(outdir, subdir) : outdir;
+    await fs.mkdir(targetDir, { recursive: true });
+    const loaderSource = createLoaderSource(languages);
+    await fs.writeFile(path.join(targetDir, 'po.js'), loaderSource);
 }
 
 async function generateTranslations({ poDirectory, subdirs, outdir, srcDirectory, wrapper }) {
     const poFiles = await listPoFiles(poDirectory);
+    const languagesBySubdir = new Map(subdirs.map(subdir => [subdir, new Set()]));
+
     await Promise.all(poFiles.flatMap(poPath =>
-        subdirs.map(subdir => buildTranslationFiles({ poPath, subdir, outdir, srcDirectory, wrapper }))
+        subdirs.map(async subdir => {
+            const languageCode = await buildTranslationFiles({ poPath, subdir, outdir, srcDirectory, wrapper });
+            languagesBySubdir.get(subdir)?.add(languageCode);
+        })
+    ));
+
+    await Promise.all(subdirs.map(subdir =>
+        writeLoader({ outdir, subdir, languages: languagesBySubdir.get(subdir) ?? new Set() })
     ));
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -25,6 +25,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="index.css">
 
     <script type="text/javascript" src="index.js"></script>
+    <script type="text/javascript" src="../base1/po.js"></script>
     <script type="text/javascript" src="po.js"></script>
 </head>
 


### PR DESCRIPTION
## Summary
- generate a po.js loader that detects the best available locale bundle after the build
- normalize locale codes and collect languages per subdirectory while writing translation assets
- include Cockpit's base1/po.js helper so the generated loader can initialize translations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e07d4fd0bc8328aa18e2d49a222108