### PR TITLE
Preserve zero timestamps in sensor parsing

### DIFF
--- a/src/__tests__/parseSensorsJson.test.ts
+++ b/src/__tests__/parseSensorsJson.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { parseSensorsJson } from '../utils/parseSensorsJson';
+
+const buildReading = (input: number) => ({
+    input,
+    label: 'Reading',
+});
+
+describe('parseSensorsJson timestamp handling', () => {
+    it('preserves a timestamp of 0 when no sensor groups are available', () => {
+        const result = parseSensorsJson({
+            timestamp: 0,
+            chips: [],
+        });
+
+        expect(result).toEqual({
+            groups: [],
+            timestamp: 0,
+        });
+    });
+
+    it('preserves a timestamp of 0 when sensor groups are present', () => {
+        const result = parseSensorsJson({
+            timestamp: 0,
+            chips: [
+                {
+                    id: 'chip-1',
+                    name: 'Chip 1',
+                    label: 'Chip 1',
+                    category: 'temperature',
+                    readings: [buildReading(42)],
+                },
+            ],
+        });
+
+        expect(result.timestamp).toBe(0);
+        expect(result.groups).toHaveLength(1);
+        expect(result.groups[0]).toMatchObject({
+            id: 'chip-1',
+            readings: [
+                expect.objectContaining({
+                    input: 42,
+                }),
+            ],
+        });
+    });
+});

--- a/src/utils/parseSensorsJson.ts
+++ b/src/utils/parseSensorsJson.ts
@@ -142,10 +142,12 @@ export const parseSensorsJson = (raw: unknown): SensorData => {
     const timestamp = coerceNumber(container.timestamp ?? container.updated ?? container.time);
 
     if (groups.length === 0) {
-        return timestamp ? { groups: [], timestamp } : { ...EMPTY_SENSOR_DATA };
+        return typeof timestamp === 'number'
+            ? { groups: [], timestamp }
+            : { ...EMPTY_SENSOR_DATA };
     }
 
-    return timestamp ? { groups, timestamp } : { groups };
+    return typeof timestamp === 'number' ? { groups, timestamp } : { groups };
 };
 
 export type { Reading, SensorChipGroup, SensorData };


### PR DESCRIPTION
## Summary
- ensure parseSensorsJson retains zero-valued timestamps instead of dropping them
- add regression tests for parsing payloads with timestamp: 0

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e219d052d48328866e77529a74f280