### PR TITLE
build: auto-detect Cockpit Sass includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ rebuilding when files change.
   `python -m http.server --directory dist`) if you need to preview the module
   in a browser outside of Cockpit.
 
+### Automatic Cockpit library detection
+
+The build tooling automatically configures the Sass include path, so you no
+longer need to export `SASS_PATH` manually. When `npm run build` or
+`npm run dev` run, the helper checks the following locations in order and adds
+the directories that exist to the Sass loader and `SASS_PATH`:
+
+1. `process.env.COCKPIT_DIR`
+2. `../cockpit/pkg/lib` (a sibling checkout of the Cockpit repository)
+3. `pkg/lib` (the local Cockpit mirror within this repository)
+
+You can still override the include path by exporting `SASS_PATH` before running
+the scripts, in which case the tooling leaves your custom value untouched.
+
 ### Mock data with `VITE_MOCK`
 
 When developing without a running Cockpit backend you can ask the application to

--- a/build-tools/sass-path.js
+++ b/build-tools/sass-path.js
@@ -1,0 +1,76 @@
+import nodeFs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(moduleDir, '..');
+
+function directoryExists(candidate) {
+    if (!candidate)
+        return false;
+
+    try {
+        return nodeFs.statSync(candidate).isDirectory();
+    } catch {
+        return false;
+    }
+}
+
+function uniqueExistingPaths(candidates) {
+    const seen = new Set();
+
+    return candidates.reduce((paths, candidate) => {
+        if (!candidate)
+            return paths;
+
+        const resolved = path.resolve(candidate);
+        if (seen.has(resolved))
+            return paths;
+
+        if (!directoryExists(resolved))
+            return paths;
+
+        seen.add(resolved);
+        paths.push(resolved);
+        return paths;
+    }, []);
+}
+
+export function resolveCockpitLibraryPaths({ baseDir = projectRoot } = {}) {
+    const envDir = process.env.COCKPIT_DIR ? path.resolve(process.env.COCKPIT_DIR) : undefined;
+
+    const candidates = [
+        envDir,
+        envDir ? path.join(envDir, 'pkg/lib') : undefined,
+        path.resolve(baseDir, '../cockpit/pkg/lib'),
+        path.resolve(baseDir, 'pkg/lib'),
+    ];
+
+    return uniqueExistingPaths(candidates);
+}
+
+export function getDefaultSassPathEntries({ baseDir = projectRoot } = {}) {
+    const cockpitLibs = resolveCockpitLibraryPaths({ baseDir });
+    const fallbackPkgLib = path.resolve(baseDir, 'pkg/lib');
+    const nodeModulesDir = path.resolve(baseDir, 'node_modules');
+
+    const entries = uniqueExistingPaths([
+        nodeModulesDir,
+        fallbackPkgLib,
+        ...cockpitLibs,
+    ]);
+
+    return entries;
+}
+
+export function ensureSassPath({ baseDir = projectRoot } = {}) {
+    if (!process.env.SASS_PATH || process.env.SASS_PATH.trim() === '') {
+        const includePaths = getDefaultSassPathEntries({ baseDir });
+        if (includePaths.length > 0)
+            process.env.SASS_PATH = includePaths.join(path.delimiter);
+    }
+
+    return process.env.SASS_PATH;
+}
+
+ensureSassPath({ baseDir: projectRoot });

--- a/build.js
+++ b/build.js
@@ -11,7 +11,9 @@ import { ArgumentParser } from 'argparse';
 
 import { cleanup } from './build-tools/cleanup.js';
 import { translationsPlugin } from './build-tools/translations.js';
-import { resolveCockpitLibraryPaths } from './build-tools/sass-path.js';
+import { ensureSassPath, resolveCockpitLibraryPaths } from './build-tools/sass-path.js';
+
+ensureSassPath();
 
 const production = process.env.NODE_ENV === 'production';
 const outdir = 'dist';

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "node": ">= 18.18"
   },
   "scripts": {
-    "build": "node -r ./build-tools/sass-path.js ./build.js",
-    "dev": "node -r ./build-tools/sass-path.js ./build.js --watch",
+    "build": "node ./build.js",
+    "dev": "node ./build.js --watch",
     "lint": "eslint .",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "node": ">= 18.18"
   },
   "scripts": {
-    "build": "node ./build.js",
-    "dev": "node ./build.js --watch",
+    "build": "node -r ./build-tools/sass-path.js ./build.js",
+    "dev": "node -r ./build-tools/sass-path.js ./build.js --watch",
     "lint": "eslint .",
     "test": "vitest run --coverage",
     "test:watch": "vitest watch"


### PR DESCRIPTION
## Summary
- add a shared helper that resolves Cockpit Sass include directories and applies them to the esbuild Sass loader
- preload the helper from the build and dev npm scripts so `SASS_PATH` defaults to the detected directories
- document the automatic discovery order for Cockpit libraries in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e367d5aa488328b1ecaa8917f3e85f