### PR TITLE
Add setup and maintenance scripts for Cockpit Sensors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /cockpit-navigator.spec
 /coverage/
 /dist/
+/pkg
 /pkg/
 /node_modules/
 /tmp/

--- a/README.md
+++ b/README.md
@@ -13,14 +13,16 @@ be installed on any host running Cockpit and builds through a custom
 - Optional but recommended: `make`, `gettext` and a working Cockpit instance for
   integration tests.
 
-Install dependencies once per clone with:
+Bootstrap a working copy with the provided script, which clones Cockpit (or
+reuses `COCKPIT_DIR`), links the shared `pkg/` directory, installs dependencies
+and performs an initial build:
 
 ```bash
-npm ci
+./scripts/setup.sh
 ```
 
-> ℹ️ `npm ci` removes existing `node_modules/` and reproduces the lockfile state
-> exactly, which keeps the development environment deterministic.
+> ℹ️ The setup script prefers `npm ci` and falls back to `npm install && npm
+> dedupe` when the stricter command is not available.
 
 ## Development workflow
 
@@ -34,6 +36,19 @@ rebuilding when files change.
 | Build the production bundle | `npm run build`
 | Run the Vitest suite with coverage | `npm run test`
 | Run ESLint over the repository | `npm run lint`
+
+After pulling updates run the maintenance helper to refresh dependencies only
+when `package-lock.json` changed and rebuild the bundle:
+
+```bash
+./scripts/maint.sh
+```
+
+The script also fetches updates in the neighbouring Cockpit checkout (or the
+location provided through `COCKPIT_DIR`) and rewrites the `pkg/` symlink to
+point at the latest sources. Continuous integration jobs can run
+`./scripts/setup.sh` for a clean install and `./scripts/maint.sh` for
+incremental builds without repeating expensive dependency work.
 
 ### Building and watching
 

--- a/scripts/maint.sh
+++ b/scripts/maint.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+COCKPIT_DIR=${COCKPIT_DIR:-"${PROJECT_ROOT}/../cockpit"}
+
+log() {
+  echo "[maint] $1"
+}
+
+if [ -d "${COCKPIT_DIR}" ]; then
+  log "Fetching updates in ${COCKPIT_DIR}"
+  git -C "${COCKPIT_DIR}" fetch --all --prune
+else
+  log "Cockpit repository not found at ${COCKPIT_DIR}; skipping fetch"
+fi
+
+PKG_TARGET="${COCKPIT_DIR}/pkg"
+PKG_LINK="${PROJECT_ROOT}/pkg"
+log "Ensuring pkg symlink points to ${PKG_TARGET}"
+if [ -e "${PKG_LINK}" ] && [ ! -L "${PKG_LINK}" ]; then
+  rm -rf "${PKG_LINK}"
+fi
+ln -sfn "${PKG_TARGET}" "${PKG_LINK}"
+
+cd "${PROJECT_ROOT}"
+PACKAGE_LOCK_CHANGED=false
+if git rev-parse HEAD@{1} >/dev/null 2>&1; then
+  if ! git diff --quiet HEAD@{1} HEAD -- package-lock.json; then
+    PACKAGE_LOCK_CHANGED=true
+  fi
+else
+  if [ -f "${PROJECT_ROOT}/package-lock.json" ]; then
+    PACKAGE_LOCK_CHANGED=true
+  fi
+fi
+
+if [ "${PACKAGE_LOCK_CHANGED}" = true ]; then
+  log "package-lock.json changed; running npm ci"
+  npm ci
+else
+  log "package-lock.json unchanged; running npm prune && npm rebuild"
+  npm prune
+  npm rebuild
+fi
+
+log "Building project assets"
+npm run build
+
+log "Build artefacts summary"
+if [ -d "${PROJECT_ROOT}/dist" ]; then
+  total_size=$(du -sh "${PROJECT_ROOT}/dist" | cut -f1)
+  file_count=$(find "${PROJECT_ROOT}/dist" -type f | wc -l | tr -d ' ')
+  log "dist/: ${total_size} across ${file_count} files"
+  find "${PROJECT_ROOT}/dist" -maxdepth 1 -type f -printf '%f\n' | sort | while read -r file; do
+    log " - ${file}"
+  done
+else
+  log "dist/ directory not found"
+fi
+
+log "Maintenance complete"
+

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+COCKPIT_DIR=${COCKPIT_DIR:-"${PROJECT_ROOT}/../cockpit"}
+
+log() {
+  echo "[setup] $1"
+}
+
+log "Preparing Cockpit checkout at ${COCKPIT_DIR}".
+if [ ! -d "${COCKPIT_DIR}" ]; then
+  log "Cloning cockpit repository (depth=1)"
+  git clone --depth=1 https://github.com/cockpit-project/cockpit.git "${COCKPIT_DIR}"
+else
+  log "Existing cockpit repository detected; skipping clone"
+fi
+
+PKG_TARGET="${COCKPIT_DIR}/pkg"
+PKG_LINK="${PROJECT_ROOT}/pkg"
+log "Linking pkg directory from ${PKG_TARGET}".
+if [ -e "${PKG_LINK}" ] && [ ! -L "${PKG_LINK}" ]; then
+  rm -rf "${PKG_LINK}"
+fi
+ln -sfn "${PKG_TARGET}" "${PKG_LINK}"
+
+cd "${PROJECT_ROOT}"
+log "Installing npm dependencies via npm ci"
+if npm ci; then
+  log "npm ci completed successfully"
+else
+  log "npm ci failed; falling back to npm install && npm dedupe"
+  npm install
+  npm dedupe
+fi
+
+log "Building project assets"
+npm run build
+log "Setup complete"
+


### PR DESCRIPTION
## Summary
- add a setup helper that clones Cockpit as needed, refreshes the pkg symlink, installs dependencies, and builds the bundle
- add a maintenance script that fetches Cockpit updates, refreshes the pkg symlink, conditionally reinstalls dependencies, and reports build artefacts
- document the new automation in the README and ignore the pkg symlink in Git

## Testing
- ./scripts/setup.sh
- ./scripts/maint.sh

------
https://chatgpt.com/codex/tasks/task_e_68e36eaffb748328b0616272faddfba0