### PR TITLE
fix: load cockpit runtime before app scripts

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -24,6 +24,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
 
     <link rel="stylesheet" href="index.css">
 
+    <script src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="index.js"></script>
     <script type="text/javascript" src="../base1/po.js"></script>
     <script type="text/javascript" src="po.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -24,6 +24,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
 
     <link rel="stylesheet" href="index.css">
 
+    <script src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="index.js"></script>
     <script type="text/javascript" src="../base1/po.js"></script>
     <script type="text/javascript" src="po.js"></script>


### PR DESCRIPTION
## Summary
- ensure cockpit runtime script loads before the application bundle in the Sensors index markup
- rebuild the distribution index to reflect the new script ordering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3fb4470848328ab18de33fbc3fd35