### PR TITLE
fix: guard Cockpit theme loader

### DIFF
--- a/src/cockpit-theme.ts
+++ b/src/cockpit-theme.ts
@@ -1,0 +1,24 @@
+/*
+ * This file attempts to synchronize with Cockpit's shell theme when the
+ * Cockpit AMD loader is available. The loader is absent during standalone
+ * builds, so the guarded require ensures the bundle can execute without
+ * errors in that environment.
+ */
+
+declare global {
+    interface Window {
+        require?: (moduleId: string) => unknown;
+    }
+}
+
+if (typeof window !== 'undefined') {
+    try {
+        const cockpitRequire = window.require;
+        if (typeof cockpitRequire === 'function')
+            cockpitRequire('cockpit-dark-theme');
+    } catch (error) {
+        // Swallow errors when Cockpit's loader is not present.
+    }
+}
+
+export {};

--- a/src/cockpit-theme.ts
+++ b/src/cockpit-theme.ts
@@ -16,7 +16,7 @@ if (typeof window !== 'undefined') {
         const cockpitRequire = window.require;
         if (typeof cockpitRequire === 'function')
             cockpitRequire('cockpit-dark-theme');
-    } catch (error) {
+    } catch {
         // Swallow errors when Cockpit's loader is not present.
     }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,8 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import './cockpit-theme';
 import '../vendor/cockpit-page.scss';
-import 'cockpit-dark-theme'; // once per page to sync with shell theme
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';


### PR DESCRIPTION
## Summary
- add a Cockpit theme shim that safely uses window.require when available
- replace the direct cockpit-dark-theme import with the guarded shim in the entry point

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3fd2d63548328932c21b6f53d945f