### PR TITLE
fix: shim require before env bootstrap

### DIFF
--- a/build.js
+++ b/build.js
@@ -120,7 +120,9 @@ function watch_dirs(dir, on_change) {
 
 const mockFlagLiteral = JSON.stringify(mockFlagValue);
 const importMetaEnvGlobalRef = '__COCKPIT_SENSORS_IMPORT_META_ENV__';
-const banner = `(() => {\n    const value = ${mockFlagLiteral};\n    const env = { VITE_MOCK: value };\n    try {\n        if (typeof globalThis !== 'undefined') {\n            globalThis.VITE_MOCK = value;\n            globalThis.${importMetaEnvGlobalRef} = env;\n        }\n    } catch (error) {\n        /* noop: non-browser environments may block global access */\n    }\n})();`;
+const requireShim = `var require = (typeof window !== 'undefined' && window.require) ? window.require : (typeof globalThis !== 'undefined' && globalThis.require ? globalThis.require : undefined);`;
+const envBootstrap = `(() => {\n    const value = ${mockFlagLiteral};\n    const env = { VITE_MOCK: value };\n    try {\n        if (typeof globalThis !== 'undefined') {\n            globalThis.VITE_MOCK = value;\n            globalThis.${importMetaEnvGlobalRef} = env;\n        }\n    } catch (error) {\n        /* noop: non-browser environments may block global access */\n    }\n})();`;
+const banner = `${requireShim}\n${envBootstrap}`;
 
 const cockpitLibPaths = resolveCockpitLibraryPaths();
 


### PR DESCRIPTION
## Summary
- add a require shim to the esbuild banner so browser builds reuse window.require before the env bootstrap runs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4014eaed08328a32ead99e1e0c777