### PR TITLE
fix: rely on global cockpit typings

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,7 @@
+import cockpitMock from '../__mocks__/cockpit';
+
+Object.defineProperty(globalThis, 'cockpit', {
+    value: cockpitMock as Cockpit,
+    configurable: true,
+    writable: true,
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,3 +1,4 @@
+import type { Cockpit } from '../types/cockpit';
 import cockpitMock from '../__mocks__/cockpit';
 
 Object.defineProperty(globalThis, 'cockpit', {

--- a/src/app/Application.tsx
+++ b/src/app/Application.tsx
@@ -32,10 +32,10 @@ import { SensorTable } from '../components/SensorTable';
 import { useSensors } from '../hooks/useSensors';
 import { SensorCategory } from '../types/sensors';
 import { groupsForCategory } from '../utils/grouping';
+import { _ } from '../utils/cockpit';
 
 import '../app.scss';
 
-const _: typeof cockpit.gettext = cockpit.gettext.bind(cockpit);
 const PAGE_SECTION_VARIANT: PageSectionProps['variant'] = 'light';
 
 type TabDefinition = {

--- a/src/app/Application.tsx
+++ b/src/app/Application.tsx
@@ -18,7 +18,6 @@
  */
 
 import React from 'react';
-import cockpit from 'cockpit';
 import {
     Content,
     Page,

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import cockpit from 'cockpit';
 
 import { Reading, SensorChipGroup } from '../types/sensors';
 

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { Reading, SensorChipGroup } from '../types/sensors';
-
-const _: typeof cockpit.gettext = cockpit.gettext.bind(cockpit);
+import { _ } from '../utils/cockpit';
 
 export interface SensorTableProps {
     groups: SensorChipGroup[];

--- a/src/types/cockpit.d.ts
+++ b/src/types/cockpit.d.ts
@@ -1,5 +1,7 @@
-interface Cockpit {
-    gettext(message: string): string;
+export type CockpitGettext = (message: string) => string;
+
+export interface Cockpit {
+    gettext: CockpitGettext;
 }
 
 declare global {

--- a/src/types/cockpit.d.ts
+++ b/src/types/cockpit.d.ts
@@ -1,8 +1,9 @@
-declare module 'cockpit' {
-    interface Cockpit {
-        gettext(message: string): string;
-    }
-
-    const cockpit: Cockpit;
-    export default cockpit;
+interface Cockpit {
+    gettext(message: string): string;
 }
+
+declare global {
+    const cockpit: Cockpit;
+}
+
+export {};

--- a/src/utils/cockpit.ts
+++ b/src/utils/cockpit.ts
@@ -1,0 +1,14 @@
+export const getCockpit = (): Cockpit => {
+    if (typeof cockpit === 'undefined') {
+        throw new ReferenceError('cockpit is not defined');
+    }
+
+    return cockpit;
+};
+
+type CockpitGettext = Cockpit['gettext'];
+
+export const gettext: CockpitGettext = ((message: Parameters<CockpitGettext>[0]) =>
+    getCockpit().gettext(message)) as CockpitGettext;
+
+export const _: CockpitGettext = gettext;

--- a/src/utils/cockpit.ts
+++ b/src/utils/cockpit.ts
@@ -1,4 +1,6 @@
-export const getCockpit = (): Cockpit => {
+import type { Cockpit, CockpitGettext } from '../types/cockpit';
+
+const resolveCockpit = (): Cockpit => {
     if (typeof cockpit === 'undefined') {
         throw new ReferenceError('cockpit is not defined');
     }
@@ -6,9 +8,8 @@ export const getCockpit = (): Cockpit => {
     return cockpit;
 };
 
-type CockpitGettext = Cockpit['gettext'];
-
-export const gettext: CockpitGettext = ((message: Parameters<CockpitGettext>[0]) =>
-    getCockpit().gettext(message)) as CockpitGettext;
+export const gettext: CockpitGettext = message => resolveCockpit().gettext(message);
 
 export const _: CockpitGettext = gettext;
+
+export const getCockpit = resolveCockpit;

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -13,5 +13,6 @@ export default defineConfig({
     },
     test: {
         environment: 'jsdom',
+        setupFiles: [resolve(__dirname, 'src/__tests__/setup.ts')],
     },
 });


### PR DESCRIPTION
## Summary
- declare the global cockpit type definition so the bundler resolves the global variable
- drop module imports of cockpit in React components and keep gettext binding against the global instance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e41d16c7c08328a32adabb4dc8340f