### PR TITLE
Add native sensor providers and improve fallback UX

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -51,3 +51,63 @@ msgstr "Erweitern Sie alle Karten"
 #: src/app.jsx:174
 msgid "Install"
 msgstr "Installieren"
+
+#: src/app/Application.tsx
+msgid "Sensor data requires administrative privileges"
+msgstr "Sensordaten erfordern administrative Berechtigungen"
+
+#: src/app/Application.tsx
+msgid "Retry with privileges"
+msgstr "Mit Berechtigungen erneut versuchen"
+
+#: src/app/Application.tsx
+msgid "Cockpit could not read sensor data without elevated permissions. Retry the operation to trigger a privilege prompt."
+msgstr "Cockpit konnte ohne erhöhte Berechtigungen keine Sensordaten lesen. Versuchen Sie den Vorgang erneut, um eine Berechtigungsabfrage auszulösen."
+
+#: src/app/Application.tsx
+msgid "No sensor backends are available on this system"
+msgstr "Auf diesem System sind keine Sensor-Backends verfügbar"
+
+#: src/app/Application.tsx
+msgid "Install the recommended packages below and rerun the detection to expose hardware monitoring sensors."
+msgstr "Installieren Sie die unten empfohlenen Pakete und führen Sie die Erkennung erneut aus, um Hardware-Überwachungssensoren bereitzustellen."
+
+#: src/app/Application.tsx
+msgid "Copy command"
+msgstr "Befehl kopieren"
+
+#: src/app/Application.tsx
+msgid "Copied"
+msgstr "Kopiert"
+
+#: src/app/Application.tsx
+msgid "Run detection again"
+msgstr "Erkennung erneut ausführen"
+
+#: src/app/Application.tsx
+msgid "No live sensor readings were reported"
+msgstr "Es wurden keine aktuellen Sensorwerte gemeldet"
+
+#: src/app/Application.tsx
+msgid "This environment may not expose physical sensors. Virtual machines commonly omit hardware monitoring interfaces."
+msgstr "Diese Umgebung stellt möglicherweise keine physischen Sensoren bereit. Virtuelle Maschinen lassen Hardware-Überwachungsschnittstellen häufig weg."
+
+#: src/app/Application.tsx
+msgid "Unable to collect sensor data"
+msgstr "Sensordaten konnten nicht gesammelt werden"
+
+#: src/app/Application.tsx
+msgid "An unexpected error prevented the Sensors page from retrieving live metrics."
+msgstr "Ein unerwarteter Fehler verhinderte, dass die Sensorseite Live-Metriken abrief."
+
+#: src/app/Application.tsx
+msgid "Try again"
+msgstr "Erneut versuchen"
+
+#: src/app/Application.tsx
+msgid "Data sources"
+msgstr "Datenquellen"
+
+#: src/app/Application.tsx
+msgid "(active)"
+msgstr "(aktiv)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -51,3 +51,63 @@ msgstr "Expandir todos os cards"
 #: src/app.jsx:174
 msgid "Install"
 msgstr "Instalar"
+
+#: src/app/Application.tsx
+msgid "Sensor data requires administrative privileges"
+msgstr "Os dados de sensores exigem privilégios administrativos"
+
+#: src/app/Application.tsx
+msgid "Retry with privileges"
+msgstr "Tentar novamente com privilégios"
+
+#: src/app/Application.tsx
+msgid "Cockpit could not read sensor data without elevated permissions. Retry the operation to trigger a privilege prompt."
+msgstr "O Cockpit não conseguiu ler os dados dos sensores sem permissões elevadas. Tente novamente para acionar o pedido de privilégios."
+
+#: src/app/Application.tsx
+msgid "No sensor backends are available on this system"
+msgstr "Nenhum backend de sensor está disponível neste sistema"
+
+#: src/app/Application.tsx
+msgid "Install the recommended packages below and rerun the detection to expose hardware monitoring sensors."
+msgstr "Instale os pacotes recomendados abaixo e execute a detecção novamente para expor os sensores de monitoramento de hardware."
+
+#: src/app/Application.tsx
+msgid "Copy command"
+msgstr "Copiar comando"
+
+#: src/app/Application.tsx
+msgid "Copied"
+msgstr "Copiado"
+
+#: src/app/Application.tsx
+msgid "Run detection again"
+msgstr "Executar a detecção novamente"
+
+#: src/app/Application.tsx
+msgid "No live sensor readings were reported"
+msgstr "Nenhuma leitura ao vivo de sensores foi informada"
+
+#: src/app/Application.tsx
+msgid "This environment may not expose physical sensors. Virtual machines commonly omit hardware monitoring interfaces."
+msgstr "Este ambiente pode não expor sensores físicos. Máquinas virtuais normalmente omitem interfaces de monitoramento de hardware."
+
+#: src/app/Application.tsx
+msgid "Unable to collect sensor data"
+msgstr "Não foi possível coletar dados dos sensores"
+
+#: src/app/Application.tsx
+msgid "An unexpected error prevented the Sensors page from retrieving live metrics."
+msgstr "Um erro inesperado impediu a página de Sensores de obter métricas em tempo real."
+
+#: src/app/Application.tsx
+msgid "Try again"
+msgstr "Tentar novamente"
+
+#: src/app/Application.tsx
+msgid "Data sources"
+msgstr "Fontes de dados"
+
+#: src/app/Application.tsx
+msgid "(active)"
+msgstr "(ativo)"

--- a/src/__tests__/useSensors.helpers.test.ts
+++ b/src/__tests__/useSensors.helpers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { __testing, SampleWithProvider } from '../hooks/useSensors';
+import { SENSOR_KIND_TO_UNIT, SensorSample } from '../lib/providers/types';
+
+const { aggregateSamples, samplesToSensorData } = __testing;
+
+describe('useSensors helpers', () => {
+    it('prefers earlier providers when aggregating samples', () => {
+        const samplesByProvider = new Map<string, SensorSample[]>();
+
+        samplesByProvider.set('lm-sensors', [
+            {
+                kind: 'temp',
+                id: 'chip0:temp1',
+                label: 'Temp 1',
+                value: 48,
+            },
+        ]);
+
+        samplesByProvider.set('hwmon', [
+            {
+                kind: 'temp',
+                id: 'chip0:temp1',
+                label: 'Temp 1',
+                value: 50,
+            },
+        ]);
+
+        const result = aggregateSamples(samplesByProvider);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({ provider: 'hwmon', value: 50 });
+    });
+
+    it('converts samples into sensor data grouped by chip and category', () => {
+        const samples: SampleWithProvider[] = [
+            {
+                provider: 'hwmon',
+                kind: 'temp',
+                id: 'chip0:temp1',
+                label: 'Core 0',
+                value: 54.5,
+                chipId: 'chip0',
+                chipLabel: 'CPU sensors',
+                chipName: 'k10temp',
+                unit: SENSOR_KIND_TO_UNIT.temp,
+            },
+            {
+                provider: 'hwmon',
+                kind: 'volt',
+                id: 'chip0:in1',
+                label: '+12V',
+                value: 12.04,
+                chipId: 'chip0',
+                chipLabel: 'CPU sensors',
+                chipName: 'k10temp',
+                unit: SENSOR_KIND_TO_UNIT.volt,
+            },
+            {
+                provider: 'nvme',
+                kind: 'temp',
+                id: '/dev/nvme0:temperature',
+                label: 'NVMe 0',
+                value: 37,
+                chipId: '/dev/nvme0',
+                chipLabel: 'NVMe 0',
+                chipName: 'NVMe',
+            },
+        ];
+
+        const data = samplesToSensorData(samples);
+        expect(data.groups).toHaveLength(3);
+
+        const cpuTemperature = data.groups.find(group => group.id === 'chip0:temperature');
+        expect(cpuTemperature).toMatchObject({
+            label: 'CPU sensors',
+            source: 'hwmon',
+        });
+        expect(cpuTemperature?.readings).toEqual([
+            expect.objectContaining({ label: 'Core 0', unit: SENSOR_KIND_TO_UNIT.temp }),
+        ]);
+
+        const cpuVoltage = data.groups.find(group => group.id === 'chip0:voltage');
+        expect(cpuVoltage?.readings[0]).toMatchObject({ label: '+12V', unit: SENSOR_KIND_TO_UNIT.volt });
+
+        const nvmeGroup = data.groups.find(group => group.id?.startsWith('/dev/nvme0'));
+        expect(nvmeGroup).toMatchObject({ source: 'nvme' });
+    });
+});

--- a/src/__tests__/useSensors.permission.test.tsx
+++ b/src/__tests__/useSensors.permission.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProviderError, type Provider, type SensorSample } from '../lib/providers/types';
+
+const hwmonProviderMock = {
+    name: 'hwmon',
+    isAvailable: vi.fn<Provider['isAvailable']>(),
+    start: vi.fn<Provider['start']>(),
+} satisfies Provider;
+
+const lmSensorsProviderMock = {
+    name: 'lm-sensors',
+    isAvailable: vi.fn<Provider['isAvailable']>(),
+    start: vi.fn<Provider['start']>(),
+} satisfies Provider;
+
+const nvmeProviderMock = {
+    name: 'nvme',
+    isAvailable: vi.fn<Provider['isAvailable']>(),
+    start: vi.fn<Provider['start']>(),
+} satisfies Provider;
+
+vi.mock('../lib/providers/hwmon', () => ({
+    hwmonProvider: hwmonProviderMock,
+}));
+
+vi.mock('../lib/providers/lm-sensors', () => ({
+    lmSensorsProvider: lmSensorsProviderMock,
+}));
+
+vi.mock('../lib/providers/nvme', () => ({
+    nvmeProvider: nvmeProviderMock,
+}));
+
+const SAMPLE: SensorSample[] = [
+    {
+        kind: 'temp',
+        id: 'chip0:temp1',
+        label: 'Core 0',
+        value: 42,
+    },
+];
+
+describe('useSensors permission handling', () => {
+    beforeEach(() => {
+        vi.useRealTimers();
+        vi.resetModules();
+
+        hwmonProviderMock.isAvailable.mockReset();
+        hwmonProviderMock.start.mockReset();
+        
+        hwmonProviderMock.isAvailable.mockResolvedValue(true);
+        hwmonProviderMock.start.mockImplementation(onChange => {
+            onChange(SAMPLE);
+            return () => {};
+        });
+
+        lmSensorsProviderMock.isAvailable.mockReset();
+        lmSensorsProviderMock.start.mockReset();
+        lmSensorsProviderMock.isAvailable.mockResolvedValue(false);
+        lmSensorsProviderMock.start.mockImplementation(() => () => {});
+
+        nvmeProviderMock.isAvailable.mockReset();
+        nvmeProviderMock.start.mockReset();
+        nvmeProviderMock.isAvailable.mockResolvedValue(true);
+        nvmeProviderMock.start.mockImplementation(() => {
+            throw new ProviderError('nvme requires privileges', 'permission-denied');
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('keeps ready state when auxiliary providers require privileges', async () => {
+        const { useSensors } = await import('../hooks/useSensors');
+        const { result } = renderHook(() => useSensors());
+
+        await waitFor(() => {
+            expect(result.current.status).toBe('ready');
+        });
+
+        expect(result.current.data.groups).not.toHaveLength(0);
+        expect(result.current.status).toBe('ready');
+        expect(result.current.availableProviders).toContain('hwmon');
+    });
+});

--- a/src/app.scss
+++ b/src/app.scss
@@ -3,3 +3,42 @@
 .sensor-description p {
     font-weight: 600;
 }
+
+.sensor-banner {
+    margin-bottom: var(--pf-global--spacer--lg);
+}
+
+.sensor-banner__copy {
+    margin-top: var(--pf-global--spacer--md);
+    max-width: 48rem;
+}
+
+.sensor-banner__action {
+    margin-top: var(--pf-global--spacer--md);
+}
+
+.sensor-banner__hint {
+    margin: var(--pf-global--spacer--sm) 0 0;
+    color: var(--pf-global--palette--black-600);
+}
+
+.sensor-sources {
+    margin-top: var(--pf-global--spacer--sm);
+}
+
+.sensor-table-container {
+    margin-top: var(--pf-global--spacer--lg);
+}
+
+.sensor-loading {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--pf-global--spacer--sm);
+    color: var(--pf-global--palette--black-700);
+}
+
+.sensor-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--pf-global--spacer--sm);
+}

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Label } from '@patternfly/react-core';
 
 import { Reading, SensorChipGroup } from '../types/sensors';
 import { _ } from '../utils/cockpit';
@@ -11,6 +12,7 @@ interface TableRow {
     key: string;
     chip: string;
     reading: Reading;
+    source?: string;
 }
 
 const MISSING_VALUE = '—';
@@ -37,6 +39,7 @@ export const SensorTable: React.FC<SensorTableProps> = ({ groups }) => {
                     key: `${group.id}-${index}`,
                     chip: group.label,
                     reading,
+                    source: group.source,
                 })),
             ),
         [groups],
@@ -67,7 +70,16 @@ export const SensorTable: React.FC<SensorTableProps> = ({ groups }) => {
 
                             return (
                                 <tr key={row.key} className={rowClassName}>
-                                    <td data-label={_('Chip')}>{row.chip}</td>
+                                    <td data-label={_('Chip')}>
+                                        <span className="sensor-chip">
+                                            <span>{row.chip}</span>
+                                            {row.source && (
+                                                <Label color="grey" isCompact>
+                                                    {row.source}
+                                                </Label>
+                                            )}
+                                        </span>
+                                    </td>
                                     <td data-label={_('Sensor')}>{reading.label}</td>
                                     <td data-label={_('Input')}>{formatValue(reading.input, reading.unit)}</td>
                                     <td data-label={_('Minimum')}>{formatValue(reading.min, reading.unit)}</td>

--- a/src/lib/providers/hwmon.ts
+++ b/src/lib/providers/hwmon.ts
@@ -1,0 +1,419 @@
+import { getCockpit } from '../../utils/cockpit';
+import type { Cockpit, CockpitSpawnError } from '../../types/cockpit';
+import { Provider, ProviderContext, ProviderError, SensorSample, SensorKind } from './types';
+
+interface HwmonSensorDescriptor {
+    id: string;
+    chipId: string;
+    chipLabel: string;
+    chipName: string;
+    kind: SensorKind;
+    label: string;
+    unit: string;
+    inputPath: string;
+    minPath?: string;
+    maxPath?: string;
+    critPath?: string;
+    scale: number;
+    min?: number;
+    max?: number;
+    critical?: number;
+}
+
+interface HwmonChipDescriptor {
+    id: string;
+    name: string;
+    label: string;
+    sensors: HwmonSensorDescriptor[];
+}
+
+const HWMON_ROOT = '/sys/class/hwmon';
+const CHIP_LIST_COMMAND = `ls -d ${HWMON_ROOT}/hwmon* 2>/dev/null`;
+const SENSOR_LIST_COMMAND = (chipPath: string) => `ls ${chipPath} 2>/dev/null`;
+
+const TRIM = (value: string): string => value.trim();
+
+const parseNumber = (value: string | null | undefined): number | undefined => {
+    if (!value) {
+        return undefined;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+        return undefined;
+    }
+
+    const parsed = Number.parseFloat(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const readFile = async (cockpitInstance: Cockpit, path: string): Promise<string | null> => {
+    try {
+        const handle = cockpitInstance.file(path);
+        const content = await handle.read();
+        handle.close();
+        return content;
+    } catch {
+        return null;
+    }
+};
+
+const readNumberFile = async (cockpitInstance: Cockpit, path: string | undefined, scale = 1): Promise<number | undefined> => {
+    if (!path) {
+        return undefined;
+    }
+
+    const content = await readFile(cockpitInstance, path);
+    const parsed = parseNumber(content ?? undefined);
+    return typeof parsed === 'number' ? parsed * scale : undefined;
+};
+
+const isPermissionDenied = (error: unknown): boolean => {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const spawnError = error as CockpitSpawnError & { message?: string };
+    if (spawnError.problem === 'access-denied') {
+        return true;
+    }
+
+    if (typeof spawnError.message === 'string' && /permission denied/i.test(spawnError.message)) {
+        return true;
+    }
+
+    return false;
+};
+
+const spawnText = async (cockpitInstance: Cockpit, command: string[] | string): Promise<string> => {
+    try {
+        return await cockpitInstance.spawn(command, { superuser: 'try', err: 'out' });
+    } catch (error) {
+        if (isPermissionDenied(error)) {
+            throw new ProviderError('Permission denied while reading hwmon data', 'permission-denied', {
+                cause: error instanceof Error ? error : undefined,
+            });
+        }
+
+        throw new ProviderError('Failed to read hwmon data from the system', 'unexpected', {
+            cause: error instanceof Error ? error : undefined,
+        });
+    }
+};
+
+const resolveSensorLabel = async (
+    cockpitInstance: Cockpit,
+    chipPath: string,
+    prefix: string,
+    index: string,
+    fallback: string,
+): Promise<string> => {
+    const labelPath = `${chipPath}/${prefix}${index}_label`;
+    const namePath = `${chipPath}/${prefix}${index}_name`;
+
+    const label = await readFile(cockpitInstance, labelPath);
+    if (label) {
+        return TRIM(label);
+    }
+
+    const name = await readFile(cockpitInstance, namePath);
+    if (name) {
+        return TRIM(name);
+    }
+
+    return fallback;
+};
+
+const sensorKindForPrefix = (prefix: string): SensorKind | null => {
+    switch (prefix) {
+        case 'temp':
+            return 'temp';
+        case 'fan':
+            return 'fan';
+        case 'in':
+            return 'volt';
+        default:
+            return null;
+    }
+};
+
+const unitForKind = (kind: SensorKind): string => {
+    switch (kind) {
+        case 'temp':
+            return '°C';
+        case 'fan':
+            return 'RPM';
+        case 'volt':
+            return 'V';
+    }
+};
+
+const scaleForKind = (kind: SensorKind): number => {
+    switch (kind) {
+        case 'temp':
+        case 'volt':
+            return 0.001;
+        case 'fan':
+        default:
+            return 1;
+    }
+};
+
+const extractSensorsFromListing = async (
+    cockpitInstance: Cockpit,
+    chipId: string,
+    chipLabel: string,
+    chipName: string,
+    chipPath: string,
+    listing: string,
+): Promise<HwmonSensorDescriptor[]> => {
+    const entries = listing
+            .split('\n')
+            .map(TRIM)
+            .filter(entry => entry.endsWith('_input'));
+
+    const descriptors: HwmonSensorDescriptor[] = [];
+
+    for (const entry of entries) {
+        const match = entry.match(/^(?<prefix>[a-z]+)(?<index>\d+)_input$/);
+        if (!match || !match.groups) {
+            continue;
+        }
+
+        const prefix = match.groups.prefix;
+        const index = match.groups.index;
+        const kind = sensorKindForPrefix(prefix);
+        if (!kind) {
+            continue;
+        }
+
+        const label = await resolveSensorLabel(cockpitInstance, chipPath, prefix, index, `${chipLabel} ${prefix}${index}`);
+        const unit = unitForKind(kind);
+        const scale = scaleForKind(kind);
+
+        descriptors.push({
+            id: `${chipId}:${prefix}${index}`,
+            chipId,
+            chipLabel,
+            chipName,
+            kind,
+            label,
+            unit,
+            scale,
+            inputPath: `${chipPath}/${entry}`,
+            minPath: `${chipPath}/${prefix}${index}_min`,
+            maxPath: `${chipPath}/${prefix}${index}_max`,
+            critPath: `${chipPath}/${prefix}${index}_crit`,
+        });
+    }
+
+    return descriptors;
+};
+
+const buildChipDescriptors = async (cockpitInstance: Cockpit): Promise<HwmonChipDescriptor[]> => {
+    const rawList = await spawnText(cockpitInstance, ['sh', '-c', CHIP_LIST_COMMAND]).catch(error => {
+        if (error instanceof ProviderError && error.code === 'unexpected') {
+            return '';
+        }
+
+        throw error;
+    });
+    const chipPaths = rawList
+            .split('\n')
+            .map(TRIM)
+            .filter(path => path.length > 0);
+
+    const chips: HwmonChipDescriptor[] = [];
+
+    for (const chipPath of chipPaths) {
+        const name = (await readFile(cockpitInstance, `${chipPath}/name`)) ?? '';
+        const label = name ? TRIM(name) : chipPath.split('/').pop() ?? chipPath;
+        const id = chipPath.split('/').pop() ?? chipPath;
+
+        const listing = await spawnText(cockpitInstance, ['sh', '-c', SENSOR_LIST_COMMAND(chipPath)]).catch(error => {
+            if (error instanceof ProviderError && error.code === 'unexpected') {
+                return '';
+            }
+
+            throw error;
+        });
+        const sensors = await extractSensorsFromListing(cockpitInstance, id, label, label, chipPath, listing);
+
+        if (sensors.length === 0) {
+            continue;
+        }
+
+        chips.push({
+            id,
+            name: label,
+            label,
+            sensors,
+        });
+    }
+
+    return chips;
+};
+
+const buildSample = (descriptor: HwmonSensorDescriptor, value: number): SensorSample => ({
+    kind: descriptor.kind,
+    id: descriptor.id,
+    label: descriptor.label,
+    value,
+    min: descriptor.min,
+    max: descriptor.max,
+    critical: descriptor.critical,
+    unit: descriptor.unit,
+    chipId: descriptor.chipId,
+    chipLabel: descriptor.chipLabel,
+    chipName: descriptor.chipName,
+});
+
+export class HwmonProvider implements Provider {
+    readonly name = 'hwmon';
+    private throttleTimeout: number | undefined;
+
+    async isAvailable(): Promise<boolean> {
+        const cockpitInstance = getCockpit();
+        const output = await spawnText(
+            cockpitInstance,
+            ['sh', '-c', `find ${HWMON_ROOT} -maxdepth 2 -type f -name "*_input" -print -quit`],
+        ).catch(error => {
+            if (error instanceof ProviderError && error.code === 'permission-denied') {
+                throw error;
+            }
+
+            return '';
+        });
+        return output.trim().length > 0;
+    }
+
+    start(onChange: (samples: SensorSample[]) => void, context?: ProviderContext) {
+        const cockpitInstance = getCockpit();
+        let disposed = false;
+        const watches: Array<() => void> = [];
+        const currentValues = new Map<string, number>();
+        const descriptors = new Map<string, HwmonSensorDescriptor>();
+
+        const emit = () => {
+            if (disposed) {
+                return;
+            }
+
+            if (typeof window !== 'undefined') {
+                if (this.throttleTimeout) {
+                    window.clearTimeout(this.throttleTimeout);
+                }
+
+                this.throttleTimeout = window.setTimeout(() => {
+                    const samples: SensorSample[] = [];
+                    for (const [id, descriptor] of descriptors) {
+                        const value = currentValues.get(id);
+                        if (typeof value !== 'number') {
+                            continue;
+                        }
+
+                        samples.push(buildSample(descriptor, value));
+                    }
+                    onChange(samples);
+                }, 500);
+                return;
+            }
+
+            const samples: SensorSample[] = [];
+            for (const [id, descriptor] of descriptors) {
+                const value = currentValues.get(id);
+                if (typeof value !== 'number') {
+                    continue;
+                }
+                samples.push(buildSample(descriptor, value));
+            }
+            onChange(samples);
+        };
+
+        const attachWatchers = async () => {
+            try {
+                const chips = await buildChipDescriptors(cockpitInstance);
+                if (chips.length === 0) {
+                    onChange([]);
+                    return;
+                }
+
+                for (const chip of chips) {
+                    for (const sensor of chip.sensors) {
+                        descriptors.set(sensor.id, sensor);
+
+                        const initialValue = await readNumberFile(
+                            cockpitInstance,
+                            sensor.inputPath,
+                            sensor.scale,
+                        );
+                        if (typeof initialValue === 'number') {
+                            currentValues.set(sensor.id, initialValue);
+                        }
+
+                        sensor.min = await readNumberFile(cockpitInstance, sensor.minPath, sensor.scale);
+                        sensor.max = await readNumberFile(cockpitInstance, sensor.maxPath, sensor.scale);
+                        sensor.critical = await readNumberFile(cockpitInstance, sensor.critPath, sensor.scale);
+
+                        const handle = cockpitInstance.file(sensor.inputPath);
+                        const stop = handle.watch(content => {
+                            if (disposed) {
+                                return;
+                            }
+
+                            if (content === null) {
+                                currentValues.delete(sensor.id);
+                                emit();
+                                return;
+                            }
+
+                            const parsed = parseNumber(content);
+                            if (typeof parsed !== 'number') {
+                                return;
+                            }
+
+                            const value = parsed * sensor.scale;
+                            currentValues.set(sensor.id, value);
+                            emit();
+                        });
+
+                        watches.push(() => {
+                            stop?.();
+                            handle.close();
+                        });
+                    }
+                }
+
+                emit();
+            } catch (error) {
+                const providerError =
+                    error instanceof ProviderError
+                        ? error
+                        : new ProviderError((error as Error).message || 'hwmon failure', 'unexpected', {
+                            cause: error instanceof Error ? error : undefined,
+                        });
+                context?.onError?.(providerError);
+            }
+        };
+
+        void attachWatchers();
+
+        return () => {
+            disposed = true;
+            if (typeof window !== 'undefined' && this.throttleTimeout) {
+                window.clearTimeout(this.throttleTimeout);
+                this.throttleTimeout = undefined;
+            }
+            for (const cancel of watches) {
+                try {
+                    cancel();
+                } catch (error) {
+                    console.error('Failed to stop hwmon watcher', error);
+                }
+            }
+            watches.length = 0;
+        };
+    }
+}
+
+export const hwmonProvider = new HwmonProvider();

--- a/src/lib/providers/lm-sensors.ts
+++ b/src/lib/providers/lm-sensors.ts
@@ -1,0 +1,261 @@
+import { getCockpit } from '../../utils/cockpit';
+import type { Cockpit, CockpitSpawnError } from '../../types/cockpit';
+import { Provider, ProviderContext, ProviderError, SensorKind, SensorSample, SENSOR_KIND_TO_UNIT } from './types';
+
+const POLL_INTERVAL_MS = 5000;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const coerceNumber = (value: unknown): number | undefined => {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : undefined;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed.length === 0) {
+            return undefined;
+        }
+
+        const parsed = Number.parseFloat(trimmed);
+        return Number.isFinite(parsed) ? parsed : undefined;
+    }
+
+    return undefined;
+};
+
+const isPermissionDenied = (error: unknown): boolean => {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const spawnError = error as CockpitSpawnError & { message?: string };
+    if (spawnError.problem === 'access-denied') {
+        return true;
+    }
+
+    if (typeof spawnError.message === 'string' && /permission denied/i.test(spawnError.message)) {
+        return true;
+    }
+
+    return false;
+};
+
+const isCommandMissing = (error: unknown): boolean => {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const spawnError = error as CockpitSpawnError & { message?: string };
+    if (spawnError.problem === 'not-found') {
+        return true;
+    }
+
+    if (spawnError.exit_status === 127) {
+        return true;
+    }
+
+    if (typeof spawnError.message === 'string') {
+        return /command not found|no such file or directory/i.test(spawnError.message);
+    }
+
+    return false;
+};
+
+const sensorKindForKey = (key: string): SensorKind | null => {
+    const match = key.match(/^([a-zA-Z]+)\d+/);
+    if (!match) {
+        return null;
+    }
+
+    const prefix = match[1].toLowerCase();
+    switch (prefix) {
+        case 'temp':
+            return 'temp';
+        case 'fan':
+            return 'fan';
+        case 'in':
+        case 'vin':
+        case 'vcc':
+            return 'volt';
+        default:
+            return null;
+    }
+};
+
+const readSensorsJson = async (cockpitInstance: Cockpit): Promise<unknown> => {
+    try {
+        const output = await cockpitInstance.spawn(['sensors', '-j'], { superuser: 'try', err: 'out' });
+        const trimmed = output.trim();
+        if (!trimmed) {
+            return {};
+        }
+
+        return JSON.parse(trimmed);
+    } catch (error) {
+        if (isPermissionDenied(error)) {
+            throw new ProviderError('Permission denied while executing sensors -j', 'permission-denied', {
+                cause: error instanceof Error ? error : undefined,
+            });
+        }
+
+        if (isCommandMissing(error)) {
+            throw new ProviderError('lm-sensors utility is not available on this system', 'unavailable', {
+                cause: error instanceof Error ? error : undefined,
+            });
+        }
+
+        const cause = error instanceof Error ? error : undefined;
+        throw new ProviderError('Failed to collect data from sensors -j', 'unexpected', { cause });
+    }
+};
+
+const parseSensorObject = (
+    chipId: string,
+    chipLabel: string,
+    sensorKey: string,
+    sensorValue: unknown,
+): SensorSample | null => {
+    if (!isRecord(sensorValue)) {
+        return null;
+    }
+
+    const inputKey = `${sensorKey}_input`;
+    const input = coerceNumber(sensorValue[inputKey]);
+    if (typeof input !== 'number') {
+        return null;
+    }
+
+    const kind = sensorKindForKey(sensorKey);
+    if (!kind) {
+        return null;
+    }
+
+    const labelCandidate = sensorValue[`${sensorKey}_label`];
+    const label = typeof labelCandidate === 'string' && labelCandidate.trim().length > 0
+        ? labelCandidate.trim()
+        : sensorKey;
+
+    const min = coerceNumber(sensorValue[`${sensorKey}_min`]);
+    const max = coerceNumber(sensorValue[`${sensorKey}_max`]);
+    const critical = coerceNumber(
+        sensorValue[`${sensorKey}_crit`] ?? sensorValue[`${sensorKey}_crit_hyst`] ?? sensorValue[`${sensorKey}_crit_alarm`],
+    );
+
+    return {
+        kind,
+        id: `${chipId}:${sensorKey}`,
+        label,
+        value: input,
+        min,
+        max,
+        critical,
+        unit: SENSOR_KIND_TO_UNIT[kind],
+        chipId,
+        chipLabel,
+        chipName: chipId,
+    };
+};
+
+const parseSensorsPayload = (payload: unknown): SensorSample[] => {
+    if (!isRecord(payload)) {
+        return [];
+    }
+
+    const samples: SensorSample[] = [];
+
+    for (const [chipId, chipValue] of Object.entries(payload)) {
+        if (!isRecord(chipValue)) {
+            continue;
+        }
+
+        const adapter = chipValue.Adapter;
+        const adapterLabel = typeof adapter === 'string' && adapter.trim().length > 0 ? adapter.trim() : undefined;
+        const chipLabel = adapterLabel ? `${chipId} (${adapterLabel})` : chipId;
+
+        for (const [sensorKey, sensorValue] of Object.entries(chipValue)) {
+            if (sensorKey === 'Adapter') {
+                continue;
+            }
+
+            const sample = parseSensorObject(chipId, chipLabel, sensorKey, sensorValue);
+            if (sample) {
+                samples.push(sample);
+            }
+        }
+    }
+
+    return samples;
+};
+
+export class LmSensorsProvider implements Provider {
+    readonly name = 'lm-sensors';
+    private intervalHandle: number | undefined;
+
+    async isAvailable(): Promise<boolean> {
+        const cockpitInstance = getCockpit();
+        const payload = await readSensorsJson(cockpitInstance).catch(error => {
+            if (error instanceof ProviderError) {
+                if (error.code === 'permission-denied') {
+                    throw error;
+                }
+
+                if (error.code === 'unavailable') {
+                    return {};
+                }
+            }
+
+            return {};
+        });
+
+        const samples = parseSensorsPayload(payload);
+        return samples.length > 0;
+    }
+
+    start(onChange: (samples: SensorSample[]) => void, context?: ProviderContext) {
+        const cockpitInstance = getCockpit();
+        let disposed = false;
+
+        const poll = async () => {
+            try {
+                const payload = await readSensorsJson(cockpitInstance);
+                if (disposed) {
+                    return;
+                }
+
+                const samples = parseSensorsPayload(payload);
+                onChange(samples);
+            } catch (error) {
+                if (disposed) {
+                    return;
+                }
+
+                if (error instanceof ProviderError) {
+                    context?.onError?.(error);
+                    if (error.code === 'permission-denied') {
+                        return;
+                    }
+                }
+            }
+        };
+
+        void poll();
+
+        if (typeof window !== 'undefined') {
+            this.intervalHandle = window.setInterval(() => {
+                void poll();
+            }, POLL_INTERVAL_MS);
+        }
+
+        return () => {
+            disposed = true;
+            if (typeof window !== 'undefined' && this.intervalHandle) {
+                window.clearInterval(this.intervalHandle);
+                this.intervalHandle = undefined;
+            }
+        };
+    }
+}
+
+export const lmSensorsProvider = new LmSensorsProvider();

--- a/src/lib/providers/nvme.ts
+++ b/src/lib/providers/nvme.ts
@@ -1,0 +1,255 @@
+import { getCockpit } from '../../utils/cockpit';
+import type { Cockpit, CockpitSpawnError } from '../../types/cockpit';
+import { Provider, ProviderContext, ProviderError, SensorSample, SENSOR_KIND_TO_UNIT } from './types';
+
+const POLL_INTERVAL_MS = 10000;
+
+interface NvmeDeviceInfo {
+    name: string;
+    model?: string;
+    serial?: string;
+}
+
+interface NvmeSmartLog {
+    composite_temperature?: number;
+    temperature?: number;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isPermissionDenied = (error: unknown): boolean => {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const spawnError = error as CockpitSpawnError & { message?: string };
+    if (spawnError.problem === 'access-denied') {
+        return true;
+    }
+
+    if (typeof spawnError.message === 'string' && /permission denied/i.test(spawnError.message)) {
+        return true;
+    }
+
+    return false;
+};
+
+const isCommandMissing = (error: unknown): boolean => {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const spawnError = error as CockpitSpawnError & { message?: string };
+    if (spawnError.problem === 'not-found') {
+        return true;
+    }
+
+    if (spawnError.exit_status === 127) {
+        return true;
+    }
+
+    if (typeof spawnError.message === 'string') {
+        return /command not found|no such file or directory/i.test(spawnError.message);
+    }
+
+    return false;
+};
+
+const runJsonCommand = async (cockpitInstance: Cockpit, command: string[]): Promise<unknown> => {
+    try {
+        const output = await cockpitInstance.spawn(command, { superuser: 'try', err: 'out' });
+        const trimmed = output.trim();
+        if (!trimmed) {
+            return {};
+        }
+
+        return JSON.parse(trimmed);
+    } catch (error) {
+        if (isPermissionDenied(error)) {
+            throw new ProviderError('Permission denied while executing nvme command', 'permission-denied', {
+                cause: error instanceof Error ? error : undefined,
+            });
+        }
+
+        if (isCommandMissing(error)) {
+            throw new ProviderError('nvme-cli is not available on this system', 'unavailable', {
+                cause: error instanceof Error ? error : undefined,
+            });
+        }
+
+        throw new ProviderError('Failed to execute nvme command', 'unexpected', {
+            cause: error instanceof Error ? error : undefined,
+        });
+    }
+};
+
+const listNvmeDevices = async (cockpitInstance: Cockpit): Promise<NvmeDeviceInfo[]> => {
+    const payload = await runJsonCommand(cockpitInstance, ['nvme', 'list', '--output-format=json']);
+    if (!isRecord(payload)) {
+        return [];
+    }
+
+    const devicesValue = payload.Devices ?? payload.devices;
+    if (!Array.isArray(devicesValue)) {
+        return [];
+    }
+
+    const devices: NvmeDeviceInfo[] = [];
+    for (const entry of devicesValue) {
+        if (!isRecord(entry)) {
+            continue;
+        }
+
+        const name = typeof entry.DevicePath === 'string'
+            ? entry.DevicePath
+            : typeof entry.Name === 'string'
+                ? entry.Name
+                : undefined;
+        if (!name) {
+            continue;
+        }
+
+        const model = typeof entry.ModelNumber === 'string' ? entry.ModelNumber.trim() : undefined;
+        const serial = typeof entry.SerialNumber === 'string' ? entry.SerialNumber.trim() : undefined;
+
+        devices.push({ name, model, serial });
+    }
+
+    return devices;
+};
+
+const readSmartLog = async (cockpitInstance: Cockpit, devicePath: string): Promise<NvmeSmartLog> => {
+    const payload = await runJsonCommand(cockpitInstance, ['nvme', 'smart-log', '--output-format=json', devicePath]);
+    if (!isRecord(payload)) {
+        return {};
+    }
+
+    return payload as NvmeSmartLog;
+};
+
+const convertTemperature = (raw?: number): number | undefined => {
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+        return undefined;
+    }
+
+    // The NVMe specification encodes composite temperatures in Kelvin.
+    if (raw > 200) {
+        return raw - 273;
+    }
+
+    return raw;
+};
+
+const buildSample = (device: NvmeDeviceInfo, temperature: number): SensorSample => {
+    const labelParts = [device.model ?? 'NVMe device'];
+    if (device.serial) {
+        labelParts.push(`#${device.serial}`);
+    }
+
+    const label = labelParts.join(' ');
+
+    return {
+        kind: 'temp',
+        id: `${device.name}:temperature`,
+        label,
+        value: temperature,
+        unit: SENSOR_KIND_TO_UNIT.temp,
+        chipId: device.name,
+        chipLabel: device.model ? `${device.model} (${device.name})` : device.name,
+        chipName: device.model ?? device.name,
+    };
+};
+
+export class NvmeProvider implements Provider {
+    readonly name = 'nvme';
+    private intervalHandle: number | undefined;
+
+    async isAvailable(): Promise<boolean> {
+        const cockpitInstance = getCockpit();
+        const devices = await listNvmeDevices(cockpitInstance).catch(error => {
+            if (error instanceof ProviderError) {
+                if (error.code === 'permission-denied') {
+                    throw error;
+                }
+
+                if (error.code === 'unavailable') {
+                    return [];
+                }
+            }
+
+            return [];
+        });
+
+        return devices.length > 0;
+    }
+
+    start(onChange: (samples: SensorSample[]) => void, context?: ProviderContext) {
+        const cockpitInstance = getCockpit();
+        let disposed = false;
+
+        const poll = async () => {
+            try {
+                const devices = await listNvmeDevices(cockpitInstance);
+                if (disposed) {
+                    return;
+                }
+
+                if (devices.length === 0) {
+                    onChange([]);
+                    return;
+                }
+
+                const samples: SensorSample[] = [];
+                for (const device of devices) {
+                    try {
+                        const log = await readSmartLog(cockpitInstance, device.name);
+                        const temperature = convertTemperature(log.composite_temperature ?? log.temperature);
+                        if (typeof temperature === 'number') {
+                            samples.push(buildSample(device, temperature));
+                        }
+                    } catch (error) {
+                        if (error instanceof ProviderError) {
+                            if (error.code === 'permission-denied') {
+                                context?.onError?.(error);
+                                return;
+                            }
+
+                            if (error.code === 'unavailable') {
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                onChange(samples);
+            } catch (error) {
+                if (disposed) {
+                    return;
+                }
+
+                if (error instanceof ProviderError) {
+                    context?.onError?.(error);
+                }
+            }
+        };
+
+        void poll();
+
+        if (typeof window !== 'undefined') {
+            this.intervalHandle = window.setInterval(() => {
+                void poll();
+            }, POLL_INTERVAL_MS);
+        }
+
+        return () => {
+            disposed = true;
+            if (typeof window !== 'undefined' && this.intervalHandle) {
+                window.clearInterval(this.intervalHandle);
+                this.intervalHandle = undefined;
+            }
+        };
+    }
+}
+
+export const nvmeProvider = new NvmeProvider();

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,0 +1,54 @@
+import type { SensorCategory } from '../../types/sensors';
+
+export type SensorKind = 'temp' | 'fan' | 'volt';
+
+export interface SensorSample {
+    kind: SensorKind;
+    id: string;
+    label: string;
+    value: number;
+    min?: number;
+    max?: number;
+    critical?: number;
+    unit?: string;
+    chipId?: string;
+    chipLabel?: string;
+    chipName?: string;
+    category?: SensorCategory;
+}
+
+export type Unsubscribe = () => void;
+
+export type ProviderErrorCode = 'permission-denied' | 'unavailable' | 'unexpected';
+
+export class ProviderError extends Error {
+    readonly code: ProviderErrorCode;
+
+    constructor(message: string, code: ProviderErrorCode = 'unexpected', options?: ErrorOptions) {
+        super(message, options);
+        this.code = code;
+        this.name = 'ProviderError';
+    }
+}
+
+export interface ProviderContext {
+    onError?: (error: ProviderError) => void;
+}
+
+export interface Provider {
+    readonly name: string;
+    start(onChange: (samples: SensorSample[]) => void, context?: ProviderContext): Unsubscribe;
+    isAvailable(): Promise<boolean>;
+}
+
+export const SENSOR_KIND_TO_CATEGORY: Record<SensorKind, SensorCategory> = {
+    temp: 'temperature',
+    fan: 'fan',
+    volt: 'voltage',
+};
+
+export const SENSOR_KIND_TO_UNIT: Record<SensorKind, string> = {
+    temp: '°C',
+    fan: 'RPM',
+    volt: 'V',
+};

--- a/src/types/cockpit.d.ts
+++ b/src/types/cockpit.d.ts
@@ -1,7 +1,47 @@
 export type CockpitGettext = (message: string) => string;
 
+export interface CockpitSpawnError {
+    problem?: string;
+    message?: string;
+    exit_status?: number;
+}
+
+export interface CockpitSpawnProcess {
+    stream(callback: (data: string) => void): CockpitSpawnProcess;
+    done(callback: (data: string) => void): CockpitSpawnProcess;
+    fail(callback: (error: CockpitSpawnError) => void): CockpitSpawnProcess;
+    cancel(): void;
+    then<TResult1 = string, TResult2 = never>(
+        onfulfilled?: ((value: string) => TResult1 | PromiseLike<TResult1>) | null,
+        onrejected?: ((reason: CockpitSpawnError) => TResult2 | PromiseLike<TResult2>) | null,
+    ): Promise<TResult1 | TResult2>;
+    catch<TResult = never>(
+        onrejected?: ((reason: CockpitSpawnError) => TResult | PromiseLike<TResult>) | null,
+    ): Promise<string | TResult>;
+}
+
+export interface CockpitFileHandle {
+    read(): Promise<string>;
+    watch(callback: (content: string | null) => void): () => void;
+    close(): void;
+}
+
+export interface CockpitSpawnOptions {
+    superuser?: 'try' | 'require' | 'never';
+    environ?: Record<string, string>;
+    err?: 'ignore' | 'message' | 'out';
+    binary?: boolean;
+}
+
+export interface CockpitFileOptions {
+    superuser?: 'try' | 'require' | 'never';
+    binary?: boolean;
+}
+
 export interface Cockpit {
     gettext: CockpitGettext;
+    spawn(command: string[] | string, options?: CockpitSpawnOptions): CockpitSpawnProcess;
+    file(path: string, options?: CockpitFileOptions): CockpitFileHandle;
 }
 
 declare global {

--- a/src/types/sensors.ts
+++ b/src/types/sensors.ts
@@ -43,6 +43,8 @@ export interface SensorChipGroup {
     category: SensorCategory;
     /** Individual sensor readings belonging to the chip. */
     readings: Reading[];
+    /** Optional indicator describing the data source/provider. */
+    source?: string;
 }
 
 /**

--- a/src/utils/parseSensorsJson.ts
+++ b/src/utils/parseSensorsJson.ts
@@ -94,6 +94,7 @@ const parseGroup = (raw: unknown, index: number): SensorChipGroup | null => {
     const name = isNonEmptyString(raw.name) ? raw.name.trim() : id;
     const label = isNonEmptyString(raw.label) ? raw.label.trim() : name;
     const category = parseCategory(raw.category);
+    const source = isNonEmptyString(raw.source) ? raw.source.trim() : undefined;
 
     const rawReadings = Array.isArray(raw.readings) ? raw.readings : Array.isArray(raw.values) ? raw.values : [];
 
@@ -105,13 +106,19 @@ const parseGroup = (raw: unknown, index: number): SensorChipGroup | null => {
         return null;
     }
 
-    return {
+    const group: SensorChipGroup = {
         id,
         name,
         label,
         category,
         readings,
     };
+
+    if (source) {
+        group.source = source;
+    }
+
+    return group;
 };
 
 /**


### PR DESCRIPTION
## Summary
- add provider interfaces for hwmon, lm-sensors, and NVMe telemetry and normalize their readings
- orchestrate provider selection in the sensors hook with privilege handling, retries, and data-source metadata
- refresh the sensors UI with banners, provider badges, styling updates, documentation, translations, and new unit tests

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e93d698588832895f11eb0ba9c3ca7