### PR TITLE
fix: normalize lm-sensors data from multiple chips

### DIFF
--- a/src/lib/providers/__tests__/lm-sensors.test.ts
+++ b/src/lib/providers/__tests__/lm-sensors.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeLmSensors } from '../lm-sensors';
+
+describe('normalizeLmSensors', () => {
+    it('flattens features from multiple chips', () => {
+        const payload = {
+            'mt7921_phy0-virtual-0': {
+                Adapter: 'Virtual device',
+                temp1: {
+                    temp1_input: 30.0,
+                },
+            },
+            'coretemp-isa-0000': {
+                Adapter: 'ISA adapter',
+                'Package id 0': {
+                    temp1_input: 55.5,
+                    temp1_label: 'Package id 0',
+                    temp1_max: 100,
+                },
+                'Core 0': {
+                    temp2_input: 44.25,
+                    temp2_label: 'Core 0',
+                },
+                'Core 1': {
+                    temp3_input: 47.75,
+                    temp3_label: 'Core 1',
+                },
+            },
+        };
+
+        const samples = normalizeLmSensors(payload);
+        const temperatureSamples = samples.filter(sample => sample.kind === 'temp');
+
+        expect(temperatureSamples).toHaveLength(4);
+        expect(temperatureSamples.map(sample => sample.label)).toEqual(
+            expect.arrayContaining(['CPU Package', 'CPU Core 0', 'CPU Core 1'])
+        );
+        const mt7921Sample = temperatureSamples.find(sample => sample.chipId === 'mt7921_phy0-virtual-0');
+        expect(mt7921Sample?.label.toLowerCase()).toContain('temp1');
+        expect(mt7921Sample?.value).toBeCloseTo(30);
+    });
+});

--- a/src/lib/providers/hwmon.ts
+++ b/src/lib/providers/hwmon.ts
@@ -145,6 +145,9 @@ const unitForKind = (kind: SensorKind): string => {
             return 'RPM';
         case 'volt':
             return 'V';
+        case 'other':
+        default:
+            return '';
     }
 };
 

--- a/src/lib/providers/lm-sensors.ts
+++ b/src/lib/providers/lm-sensors.ts
@@ -1,6 +1,14 @@
 import { getCockpit } from '../../utils/cockpit';
 import type { Cockpit, CockpitSpawnError } from '../../types/cockpit';
-import { Provider, ProviderContext, ProviderError, SensorKind, SensorSample, SENSOR_KIND_TO_UNIT } from './types';
+import {
+    Provider,
+    ProviderContext,
+    ProviderError,
+    SensorKind,
+    SensorSample,
+    SENSOR_KIND_TO_CATEGORY,
+    SENSOR_KIND_TO_UNIT,
+} from './types';
 
 const POLL_INTERVAL_MS = 5000;
 
@@ -63,10 +71,12 @@ const isCommandMissing = (error: unknown): boolean => {
     return false;
 };
 
-const sensorKindForKey = (key: string): SensorKind | null => {
-    const match = key.match(/^([a-zA-Z]+)\d+/);
+const INPUT_SUFFIX = '_input';
+
+const sensorKindForKey = (key: string): SensorKind => {
+    const match = key.match(/^([a-zA-Z]+)/);
     if (!match) {
-        return null;
+        return 'other';
     }
 
     const prefix = match[1].toLowerCase();
@@ -80,13 +90,27 @@ const sensorKindForKey = (key: string): SensorKind | null => {
         case 'vcc':
             return 'volt';
         default:
-            return null;
+            return 'other';
     }
+};
+
+const prettifyLabel = (label: string): string => {
+    const trimmed = label.trim();
+    if (/^package id\s*\d+$/i.test(trimmed)) {
+        return 'CPU Package';
+    }
+
+    const coreMatch = trimmed.match(/^core\s*(\d+)$/i);
+    if (coreMatch) {
+        return `CPU Core ${coreMatch[1]}`;
+    }
+
+    return trimmed;
 };
 
 const readSensorsJson = async (cockpitInstance: Cockpit): Promise<unknown> => {
     try {
-        const output = await cockpitInstance.spawn(['sensors', '-j'], { superuser: 'try', err: 'out' });
+        const output = await cockpitInstance.spawn(['sensors', '-jA'], { superuser: 'try', err: 'out' });
         const trimmed = output.trim();
         if (!trimmed) {
             return {};
@@ -111,42 +135,40 @@ const readSensorsJson = async (cockpitInstance: Cockpit): Promise<unknown> => {
     }
 };
 
-const parseSensorObject = (
+const buildSample = (
     chipId: string,
     chipLabel: string,
-    sensorKey: string,
-    sensorValue: unknown,
+    groupKey: string,
+    featureKey: string,
+    featureValue: unknown,
+    featureRecord: Record<string, unknown>,
 ): SensorSample | null => {
-    if (!isRecord(sensorValue)) {
-        return null;
-    }
-
-    const inputKey = `${sensorKey}_input`;
-    const input = coerceNumber(sensorValue[inputKey]);
+    const input = coerceNumber(featureValue);
     if (typeof input !== 'number') {
         return null;
     }
 
-    const kind = sensorKindForKey(sensorKey);
-    if (!kind) {
-        return null;
-    }
+    const kind = sensorKindForKey(featureKey);
+    const baseKey = featureKey.replace(new RegExp(`${INPUT_SUFFIX}$`), '');
 
-    const labelCandidate = sensorValue[`${sensorKey}_label`];
-    const label = typeof labelCandidate === 'string' && labelCandidate.trim().length > 0
-        ? labelCandidate.trim()
-        : sensorKey;
+    const labelCandidate = featureRecord[`${baseKey}_label`];
+    const fallbackLabel =
+        typeof groupKey === 'string' && groupKey.trim().length > 0 && groupKey !== chipId ? groupKey : undefined;
+    const label =
+        (typeof labelCandidate === 'string' && labelCandidate.trim().length > 0
+            ? labelCandidate.trim()
+            : fallbackLabel) ?? baseKey;
 
-    const min = coerceNumber(sensorValue[`${sensorKey}_min`]);
-    const max = coerceNumber(sensorValue[`${sensorKey}_max`]);
-    const critical = coerceNumber(
-        sensorValue[`${sensorKey}_crit`] ?? sensorValue[`${sensorKey}_crit_hyst`] ?? sensorValue[`${sensorKey}_crit_alarm`],
+    const min = coerceNumber(featureRecord[`${baseKey}_min`] ?? featureRecord[`${baseKey}_low`]);
+    const max = coerceNumber(
+        featureRecord[`${baseKey}_max`] ?? featureRecord[`${baseKey}_high`] ?? featureRecord[`${baseKey}_crit`],
     );
+    const critical = coerceNumber(featureRecord[`${baseKey}_crit`]);
 
     return {
         kind,
-        id: `${chipId}:${sensorKey}`,
-        label,
+        id: `${chipId}:${baseKey}`,
+        label: prettifyLabel(label),
         value: input,
         min,
         max,
@@ -155,10 +177,33 @@ const parseSensorObject = (
         chipId,
         chipLabel,
         chipName: chipId,
+        category: SENSOR_KIND_TO_CATEGORY[kind],
     };
 };
 
-const parseSensorsPayload = (payload: unknown): SensorSample[] => {
+const collectGroupSamples = (
+    chipId: string,
+    chipLabel: string,
+    groupKey: string,
+    groupValue: Record<string, unknown>,
+): SensorSample[] => {
+    const samples: SensorSample[] = [];
+
+    for (const [featureKey, featureValue] of Object.entries(groupValue)) {
+        if (!featureKey.endsWith(INPUT_SUFFIX)) {
+            continue;
+        }
+
+        const sample = buildSample(chipId, chipLabel, groupKey, featureKey, featureValue, groupValue);
+        if (sample) {
+            samples.push(sample);
+        }
+    }
+
+    return samples;
+};
+
+export const normalizeLmSensors = (payload: unknown): SensorSample[] => {
     if (!isRecord(payload)) {
         return [];
     }
@@ -179,8 +224,21 @@ const parseSensorsPayload = (payload: unknown): SensorSample[] => {
                 continue;
             }
 
-            const sample = parseSensorObject(chipId, chipLabel, sensorKey, sensorValue);
-            if (sample) {
+            if (sensorKey.endsWith(INPUT_SUFFIX)) {
+                const featureRecord = chipValue as Record<string, unknown>;
+                const sample = buildSample(chipId, chipLabel, chipId, sensorKey, sensorValue, featureRecord);
+                if (sample) {
+                    samples.push(sample);
+                }
+                continue;
+            }
+
+            if (!isRecord(sensorValue)) {
+                continue;
+            }
+
+            const groupSamples = collectGroupSamples(chipId, chipLabel, sensorKey, sensorValue);
+            for (const sample of groupSamples) {
                 samples.push(sample);
             }
         }
@@ -209,7 +267,7 @@ export class LmSensorsProvider implements Provider {
             return {};
         });
 
-        const samples = parseSensorsPayload(payload);
+        const samples = normalizeLmSensors(payload);
         return samples.length > 0;
     }
 
@@ -224,7 +282,7 @@ export class LmSensorsProvider implements Provider {
                     return;
                 }
 
-                const samples = parseSensorsPayload(payload);
+                const samples = normalizeLmSensors(payload);
                 onChange(samples);
             } catch (error) {
                 if (disposed) {

--- a/src/lib/providers/lm-sensors.ts
+++ b/src/lib/providers/lm-sensors.ts
@@ -225,7 +225,7 @@ export const normalizeLmSensors = (payload: unknown): SensorSample[] => {
             }
 
             if (sensorKey.endsWith(INPUT_SUFFIX)) {
-                const featureRecord = chipValue as Record<string, unknown>;
+                const featureRecord = chipValue;
                 const sample = buildSample(chipId, chipLabel, chipId, sensorKey, sensorValue, featureRecord);
                 if (sample) {
                     samples.push(sample);

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,6 +1,6 @@
 import type { SensorCategory } from '../../types/sensors';
 
-export type SensorKind = 'temp' | 'fan' | 'volt';
+export type SensorKind = 'temp' | 'fan' | 'volt' | 'other';
 
 export interface SensorSample {
     kind: SensorKind;
@@ -45,10 +45,12 @@ export const SENSOR_KIND_TO_CATEGORY: Record<SensorKind, SensorCategory> = {
     temp: 'temperature',
     fan: 'fan',
     volt: 'voltage',
+    other: 'unknown',
 };
 
-export const SENSOR_KIND_TO_UNIT: Record<SensorKind, string> = {
+export const SENSOR_KIND_TO_UNIT: Record<SensorKind, string | undefined> = {
     temp: '°C',
     fan: 'RPM',
     volt: 'V',
+    other: undefined,
 };


### PR DESCRIPTION
## Summary
- flatten lm-sensors JSON payloads so readings from all chip groups are surfaced with friendly CPU package/core labels
- extend sensor kind handling to cover an "other" type while keeping hwmon compatibility
- add a Vitest case for the multi-chip coretemp fixture to guard the new normalizer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e94d0affa083288b30a4ea4b2d364d