### PR TITLE
feat: add sensor session metrics and ui enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- Expand the Sensors table to full width within Cockpit.
+- Persist sensor history in memory to expose per-session min/avg/max stats.
+- Add sparkline trend visualisations and threshold-based highlighting.
+- Provide toolbar controls for refresh interval, °C/°F toggle and CSV export.
+- Allow pinning favourite sensors and surface clear zero states per category.
+- Persist refresh, unit and pinned preferences via localStorage.
+- Document the new session analytics workflow and add coverage for helpers.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ Commands are executed via `cockpit.spawn(..., { superuser: 'try' })`. Should the
 host require elevated permissions, the page displays a “Retry with privileges”
 call to action that re-triggers detection and prompts Cockpit to escalate.
 
+### Session analytics and export
+
+The Sensors table keeps a short rolling history in memory for each detected
+sensor (up to 300 samples). The UI exposes per-session minimum/average/maximum
+stats, an inline sparkline trend and controls to highlight values approaching or
+exceeding the reported thresholds. Operators can pin high-priority sensors to
+the top, switch between Celsius and Fahrenheit without resetting the history,
+choose the polling interval (2/5/10 seconds) and export the captured timeline as
+CSV for offline analysis. All preferences persist via `localStorage` so that the
+page restores the previous state on reload.
+
 ## Installing the bundle in Cockpit
 
 1. Build the project:

--- a/po/de.po
+++ b/po/de.po
@@ -111,3 +111,114 @@ msgstr "Datenquellen"
 #: src/app/Application.tsx
 msgid "(active)"
 msgstr "(aktiv)"
+#: src/components/SensorTable.tsx
+msgid "No temperature sensors detected"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Cockpit did not receive any temperature readings for this system."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No fan telemetry available"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "The hardware monitoring stack did not expose any fan speed sensors."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No voltage sensors reported"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No voltage inputs were reported by the available sensor backends."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No power sensors found"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Power metrics were not exposed for this host or backend."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No miscellaneous sensors captured"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Sensors outside the dedicated categories are not reporting data."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Sensor table controls"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Refresh interval"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Refresh interval selector"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Every 10 seconds"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Every 5 seconds"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Every 2 seconds"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Temperature unit"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Temperature unit selector"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Degrees Celsius (°C)"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Degrees Fahrenheit (°F)"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Download session history as CSV"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Export CSV"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Pinned status"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Pin sensor"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Unpin sensor"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Session min/avg/max"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Trend"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Source"
+msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -111,3 +111,114 @@ msgstr "Fontes de dados"
 #: src/app/Application.tsx
 msgid "(active)"
 msgstr "(ativo)"
+#: src/components/SensorTable.tsx
+msgid "No temperature sensors detected"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Cockpit did not receive any temperature readings for this system."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No fan telemetry available"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "The hardware monitoring stack did not expose any fan speed sensors."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No voltage sensors reported"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No voltage inputs were reported by the available sensor backends."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No power sensors found"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Power metrics were not exposed for this host or backend."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "No miscellaneous sensors captured"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Sensors outside the dedicated categories are not reporting data."
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Sensor table controls"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Refresh interval"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Refresh interval selector"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Every 10 seconds"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Every 5 seconds"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Every 2 seconds"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Temperature unit"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Temperature unit selector"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Degrees Celsius (°C)"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Degrees Fahrenheit (°F)"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Download session history as CSV"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Export CSV"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Pinned status"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Pin sensor"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Unpin sensor"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Session min/avg/max"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Trend"
+msgstr ""
+
+#: src/components/SensorTable.tsx
+msgid "Source"
+msgstr ""

--- a/src/__mocks__/@patternfly/react-core.ts
+++ b/src/__mocks__/@patternfly/react-core.ts
@@ -10,7 +10,9 @@ const createElement = (tag: keyof JSX.IntrinsicElements) =>
     };
 
 export const Alert = ({ title, children, ...props }: React.PropsWithChildren<{ title?: React.ReactNode } & AnyProps>) => {
-    const { variant: _variant, isInline: _isInline, ...rest } = props;
+    const { variant, isInline, ...rest } = props;
+    void variant;
+    void isInline;
     return React.createElement('section', rest, title, children);
 };
 
@@ -20,16 +22,22 @@ export const Button = ({ children, isDisabled, ...props }: ComponentProps & { is
     React.createElement('button', { ...props, disabled: isDisabled }, children);
 export const ClipboardCopy = ({ children }: ComponentProps) => React.createElement('pre', null, children);
 export const Content = createElement('section');
-export const Label = ({ children, isCompact: _isCompact, ...props }: ComponentProps & { isCompact?: boolean }) =>
-    React.createElement('span', props, children);
-export const LabelGroup = ({
-    children,
-    categoryName: _categoryName,
-    ...props
-}: ComponentProps & { categoryName?: React.ReactNode }) => React.createElement('div', props, children);
+export const Label = ({ children, ...props }: ComponentProps & { isCompact?: boolean }) => {
+    const { isCompact, ...rest } = props;
+    void isCompact;
+    return React.createElement('span', rest, children);
+};
+export const LabelGroup = ({ children, ...props }: ComponentProps & { categoryName?: React.ReactNode }) => {
+    const { categoryName, ...rest } = props;
+    void categoryName;
+    return React.createElement('div', rest, children);
+};
 export const Page = createElement('main');
 export const PageSection = ({ children, ...props }: ComponentProps) => {
-    const { variant: _variant, isFilled: _isFilled, isWidthLimited: _isWidthLimited, ...rest } = props;
+    const { variant, isFilled, isWidthLimited, ...rest } = props;
+    void variant;
+    void isFilled;
+    void isWidthLimited;
     return React.createElement('section', rest, children);
 };
 export const Spinner = createElement('div');
@@ -39,11 +47,17 @@ export const Tabs = ({ children }: ComponentProps) => React.createElement(React.
 
 export const EmptyState = ({ children }: ComponentProps) => React.createElement('div', null, children);
 export const EmptyStateBody = ({ children }: ComponentProps) => React.createElement('p', null, children);
-export const EmptyStateHeader = ({ icon, titleText, headingLevel = 'h2' }: { icon?: React.ReactNode; titleText?: React.ReactNode; headingLevel?: string }) =>
-    React.createElement(headingLevel as keyof JSX.IntrinsicElements, null, icon, titleText);
+type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+
+export const EmptyStateHeader = ({
+    icon,
+    titleText,
+    headingLevel = 'h2',
+}: { icon?: React.ReactNode; titleText?: React.ReactNode; headingLevel?: HeadingLevel }) =>
+    React.createElement(headingLevel, null, icon, titleText);
 export const EmptyStateIcon = ({ icon }: { icon?: React.ElementType }) => {
-    const Icon = icon ?? 'span';
-    return React.createElement(Icon as React.ElementType, null);
+    const IconComponent: React.ElementType = icon ?? 'span';
+    return React.createElement(IconComponent, null);
 };
 
 export const Toolbar = createElement('div');

--- a/src/__mocks__/@patternfly/react-core.ts
+++ b/src/__mocks__/@patternfly/react-core.ts
@@ -1,0 +1,73 @@
+import React from 'react';
+
+type AnyProps = Record<string, unknown>;
+
+type ComponentProps = React.PropsWithChildren<AnyProps>;
+
+const createElement = (tag: keyof JSX.IntrinsicElements) =>
+    function MockComponent({ children, ...props }: ComponentProps) {
+        return React.createElement(tag, props, children);
+    };
+
+export const Alert = ({ title, children, ...props }: React.PropsWithChildren<{ title?: React.ReactNode } & AnyProps>) => {
+    const { variant: _variant, isInline: _isInline, ...rest } = props;
+    return React.createElement('section', rest, title, children);
+};
+
+export const AlertActionLink = createElement('button');
+export const AlertVariant = { info: 'info', warning: 'warning', danger: 'danger' } as const;
+export const Button = ({ children, isDisabled, ...props }: ComponentProps & { isDisabled?: boolean }) =>
+    React.createElement('button', { ...props, disabled: isDisabled }, children);
+export const ClipboardCopy = ({ children }: ComponentProps) => React.createElement('pre', null, children);
+export const Content = createElement('section');
+export const Label = ({ children, isCompact: _isCompact, ...props }: ComponentProps & { isCompact?: boolean }) =>
+    React.createElement('span', props, children);
+export const LabelGroup = ({
+    children,
+    categoryName: _categoryName,
+    ...props
+}: ComponentProps & { categoryName?: React.ReactNode }) => React.createElement('div', props, children);
+export const Page = createElement('main');
+export const PageSection = ({ children, ...props }: ComponentProps) => {
+    const { variant: _variant, isFilled: _isFilled, isWidthLimited: _isWidthLimited, ...rest } = props;
+    return React.createElement('section', rest, children);
+};
+export const Spinner = createElement('div');
+export const Tab = ({ children }: ComponentProps) => React.createElement(React.Fragment, null, children);
+export const TabTitleText = ({ children }: ComponentProps) => React.createElement(React.Fragment, null, children);
+export const Tabs = ({ children }: ComponentProps) => React.createElement(React.Fragment, null, children);
+
+export const EmptyState = ({ children }: ComponentProps) => React.createElement('div', null, children);
+export const EmptyStateBody = ({ children }: ComponentProps) => React.createElement('p', null, children);
+export const EmptyStateHeader = ({ icon, titleText, headingLevel = 'h2' }: { icon?: React.ReactNode; titleText?: React.ReactNode; headingLevel?: string }) =>
+    React.createElement(headingLevel as keyof JSX.IntrinsicElements, null, icon, titleText);
+export const EmptyStateIcon = ({ icon }: { icon?: React.ElementType }) => {
+    const Icon = icon ?? 'span';
+    return React.createElement(Icon as React.ElementType, null);
+};
+
+export const Toolbar = createElement('div');
+export const ToolbarContent = createElement('div');
+export const ToolbarGroup = createElement('div');
+export const ToolbarItem = createElement('div');
+
+interface FormSelectProps extends ComponentProps {
+    value?: string;
+    onChange?: (value: string, event: React.ChangeEvent<HTMLSelectElement>) => void;
+}
+
+export const FormSelect = ({ value, onChange, children, ...props }: FormSelectProps) =>
+    React.createElement(
+        'select',
+        {
+            ...props,
+            value,
+            onChange: (event: React.ChangeEvent<HTMLSelectElement>) => onChange?.(event.target.value, event),
+        },
+        children,
+    );
+
+export const FormSelectOption = ({ value, label }: { value: string | number; label?: React.ReactNode }) =>
+    React.createElement('option', { value }, label ?? value);
+
+export const Tooltip = ({ children }: ComponentProps) => React.createElement(React.Fragment, null, children);

--- a/src/__mocks__/@patternfly/react-icons.ts
+++ b/src/__mocks__/@patternfly/react-icons.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+
+const createIcon = (name: string) => () => React.createElement('span', { "data-icon": name });
+
+export const DownloadIcon = createIcon('DownloadIcon');
+export const OutlinedStarIcon = createIcon('OutlinedStarIcon');
+export const StarIcon = createIcon('StarIcon');
+export const SearchIcon = createIcon('SearchIcon');

--- a/src/__mocks__/@patternfly/react-icons.ts
+++ b/src/__mocks__/@patternfly/react-icons.ts
@@ -1,6 +1,10 @@
 import React from 'react';
 
-const createIcon = (name: string) => () => React.createElement('span', { "data-icon": name });
+const createIcon = (name: string) => {
+    const Icon = () => React.createElement('span', { 'data-icon': name });
+    Icon.displayName = name;
+    return Icon;
+};
 
 export const DownloadIcon = createIcon('DownloadIcon');
 export const OutlinedStarIcon = createIcon('OutlinedStarIcon');

--- a/src/__tests__/Application.test.tsx
+++ b/src/__tests__/Application.test.tsx
@@ -3,9 +3,9 @@ import { cleanup, render, screen } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mocks = vi.hoisted(() => ({
-    useSensors: vi.fn(),
-}));
+import type { UseSensorsResult } from '../hooks/useSensors';
+
+const useSensorsMock = vi.fn<(refreshMs?: number) => UseSensorsResult>();
 
 vi.mock('@patternfly/react-core', async () => await import('../__mocks__/@patternfly/react-core'));
 vi.mock('@patternfly/react-icons', async () => await import('../__mocks__/@patternfly/react-icons'));
@@ -27,7 +27,7 @@ vi.mock('../hooks/useSensorPreferences', () => ({
     }),
 }));
 vi.mock('../hooks/useSensors', () => ({
-    useSensors: (...args: unknown[]) => mocks.useSensors(...args),
+    useSensors: (refreshMs?: number) => useSensorsMock(refreshMs),
 }));
 vi.mock(
     'cockpit',
@@ -47,7 +47,7 @@ describe('Application', () => {
     });
 
     beforeEach(() => {
-        mocks.useSensors.mockReset();
+        useSensorsMock.mockReset();
     });
 
     afterEach(() => {
@@ -55,7 +55,7 @@ describe('Application', () => {
     });
 
     it('renders the onboarding banner when no backends are available', () => {
-        mocks.useSensors.mockReturnValue({
+        useSensorsMock.mockReturnValue({
             data: { groups: [] },
             isLoading: false,
             status: 'no-sources',
@@ -67,12 +67,12 @@ describe('Application', () => {
 
         render(<Application />);
 
-        expect(mocks.useSensors).toHaveBeenCalledWith(5000);
+        expect(useSensorsMock).toHaveBeenCalledWith(5000);
         expect(screen.getByText('No sensor backends are available on this system')).toBeInTheDocument();
     });
 
     it('shows available providers when sensor groups are present', () => {
-        mocks.useSensors.mockReturnValue({
+        useSensorsMock.mockReturnValue({
             data: {
                 groups: [
                     {

--- a/src/__tests__/SensorTable.test.tsx
+++ b/src/__tests__/SensorTable.test.tsx
@@ -1,0 +1,88 @@
+import '@testing-library/jest-dom/vitest';
+import React from 'react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SensorTable } from '../components/SensorTable';
+import type { SensorChipGroup } from '../types/sensors';
+
+vi.mock('@patternfly/react-core', async () => await import('../__mocks__/@patternfly/react-core'));
+vi.mock('@patternfly/react-icons', async () => await import('../__mocks__/@patternfly/react-icons'));
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+afterEach(() => {
+    cleanup();
+});
+
+describe('SensorTable component', () => {
+    const groups: SensorChipGroup[] = [
+        {
+            id: 'chip1',
+            name: 'chip1',
+            label: 'chip1',
+            category: 'temperature',
+            readings: [
+                { label: 'CPU', input: 42, unit: '°C', max: 80, critical: 90 },
+                { label: 'Board', input: 38, unit: '°C', max: 75, critical: 85 },
+            ],
+            source: 'hwmon',
+        },
+    ];
+
+    it('renders a table with rows and sparkline placeholders', () => {
+        const { container } = render(
+            <SensorTable
+                groups={groups}
+                category="temperature"
+                unit="C"
+                onUnitChange={() => {}}
+                refreshMs={5000}
+                onRefreshChange={() => {}}
+                pinnedKeys={[]}
+                onTogglePinned={() => {}}
+            />,
+        );
+
+        expect(screen.getByRole('grid', { name: /sensor readings/i })).toBeInTheDocument();
+        expect(container.querySelectorAll('svg').length).toBeGreaterThan(0);
+    });
+
+    it('renders pinned sensors before others', () => {
+        render(
+            <SensorTable
+                groups={groups}
+                category="temperature"
+                unit="C"
+                onUnitChange={() => {}}
+                refreshMs={5000}
+                onRefreshChange={() => {}}
+                pinnedKeys={['chip1:CPU']}
+                onTogglePinned={() => {}}
+            />,
+        );
+
+        const table = screen.getAllByRole('grid', { name: /sensor readings/i })[0];
+        const rows = within(table).getAllByRole('row');
+        expect(within(rows[1]).getByText('CPU')).toBeInTheDocument();
+    });
+
+    it('shows a zero state when there are no readings', () => {
+        render(
+            <SensorTable
+                groups={[]}
+                category="temperature"
+                unit="C"
+                onUnitChange={() => {}}
+                refreshMs={5000}
+                onRefreshChange={() => {}}
+                pinnedKeys={[]}
+                onTogglePinned={() => {}}
+            />,
+        );
+
+        expect(document.querySelector('.sensor-zero-state')).not.toBeNull();
+    });
+});

--- a/src/__tests__/SensorTable.test.tsx
+++ b/src/__tests__/SensorTable.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import React from 'react';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SensorTable } from '../components/SensorTable';

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,5 +1,33 @@
+import React from 'react';
+import { vi } from 'vitest';
+
 import type { Cockpit } from '../types/cockpit';
 import cockpitMock from '../__mocks__/cockpit';
+
+vi.mock('@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateHeader', () => ({
+    EmptyStateHeader: ({
+        icon,
+        titleText,
+        headingLevel = 'h2',
+    }: {
+        icon?: React.ReactNode;
+        titleText?: React.ReactNode;
+        headingLevel?: keyof JSX.IntrinsicElements;
+    }) => {
+        const Heading = headingLevel ?? 'h2';
+        return React.createElement(
+            'div',
+            null,
+            icon,
+            titleText ? React.createElement(Heading, null, titleText) : null,
+        );
+    },
+}));
+
+vi.mock('@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon', () => ({
+    EmptyStateIcon: ({ icon: Icon }: { icon?: React.ElementType }) =>
+        Icon ? React.createElement(Icon, null) : null,
+}));
 
 Object.defineProperty(globalThis, 'cockpit', {
     value: cockpitMock as Cockpit,

--- a/src/app.scss
+++ b/src/app.scss
@@ -30,6 +30,39 @@
     margin-top: var(--pf-global--spacer--lg);
 }
 
+.sensor-toolbar {
+    margin-bottom: var(--pf-global--spacer--md);
+}
+
+.sensor-toolbar__label {
+    display: block;
+    font-size: var(--pf-global--FontSize--sm);
+    color: var(--pf-global--palette--black-600);
+    margin-bottom: var(--pf-global--spacer--xs);
+}
+
+.sensor-reading {
+    font-variant-numeric: tabular-nums;
+}
+
+.sensor-reading--normal {
+    color: inherit;
+}
+
+.sensor-reading--warning {
+    color: var(--pf-global--warning-color--100);
+    font-weight: 600;
+}
+
+.sensor-reading--danger {
+    color: var(--pf-global--danger-color--100);
+    font-weight: 600;
+}
+
+.sensor-zero-state {
+    margin-top: var(--pf-global--spacer--xl);
+}
+
 .sensor-loading {
     display: inline-flex;
     align-items: center;

--- a/src/app/Application.tsx
+++ b/src/app/Application.tsx
@@ -38,6 +38,7 @@ import {
 
 import { SensorTable } from '../components/SensorTable';
 import { useSensors } from '../hooks/useSensors';
+import { useSensorPreferences } from '../hooks/useSensorPreferences';
 import { SensorCategory } from '../types/sensors';
 import { groupsForCategory } from '../utils/grouping';
 import { _ } from '../utils/cockpit';
@@ -84,7 +85,8 @@ const TABS: readonly TabDefinition[] = [
 
 export const Application: React.FC = () => {
     const [activeKey, setActiveKey] = React.useState<number>(TABS[0].eventKey);
-    const { data, isLoading, status, activeProvider, lastError, availableProviders, retry } = useSensors();
+    const { unit, setUnit, refreshMs, setRefreshMs, pinned, togglePinned } = useSensorPreferences();
+    const { data, isLoading, status, activeProvider, lastError, availableProviders, retry } = useSensors(refreshMs);
 
     const handleTabSelect = React.useCallback<NonNullable<React.ComponentProps<typeof Tabs>['onSelect']>>(
         (_event, eventKey) => {
@@ -175,7 +177,7 @@ export const Application: React.FC = () => {
 
     return (
         <Page>
-            <PageSection variant={PAGE_SECTION_VARIANT} isFilled>
+            <PageSection variant={PAGE_SECTION_VARIANT} isFilled isWidthLimited={false}>
                 <div className="sensor-banner">{renderBanner()}</div>
                 <Tabs
                     activeKey={activeKey}
@@ -208,7 +210,18 @@ export const Application: React.FC = () => {
                                         <span>{_('Loading sensor data...')}</span>
                                     </div>
                                 )}
-                                {!isLoading && <SensorTable groups={getGroupsForCategory(tab.category)} />}
+                                {!isLoading && (
+                                    <SensorTable
+                                        category={tab.category}
+                                        groups={getGroupsForCategory(tab.category)}
+                                        unit={unit}
+                                        onUnitChange={setUnit}
+                                        refreshMs={refreshMs}
+                                        onRefreshChange={setRefreshMs}
+                                        pinnedKeys={pinned}
+                                        onTogglePinned={togglePinned}
+                                    />
+                                )}
                             </div>
                         </Tab>
                     ))}

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -3,8 +3,6 @@ import {
     Button,
     EmptyState,
     EmptyStateBody,
-    EmptyStateHeader,
-    EmptyStateIcon,
     FormSelect,
     FormSelectOption,
     Label,
@@ -14,6 +12,8 @@ import {
     ToolbarItem,
     Tooltip,
 } from '@patternfly/react-core';
+import { EmptyStateHeader } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateHeader';
+import { EmptyStateIcon } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateIcon';
 import { DownloadIcon, OutlinedStarIcon, SearchIcon, StarIcon } from '@patternfly/react-icons';
 
 import { Sparkline } from './Sparkline';

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -180,7 +180,7 @@ export const SensorTable: React.FC<SensorTableProps> = ({
                     }
                     return collator.compare(a.readingLabel, b.readingLabel);
                 });
-    }, [rows, pinnedKeys, pinnedIndex, historyVersion]);
+    }, [rows, pinnedKeys, pinnedIndex]);
 
     React.useEffect(() => {
         const history = historyRef.current;
@@ -267,7 +267,7 @@ export const SensorTable: React.FC<SensorTableProps> = ({
         anchor.click();
         document.body.removeChild(anchor);
         URL.revokeObjectURL(url);
-    }, [sortedRows, unit, historyVersion]);
+    }, [sortedRows, unit]);
 
     const handleUnitToggle = React.useCallback(
         (nextUnit: TemperatureUnit) => {
@@ -277,6 +277,7 @@ export const SensorTable: React.FC<SensorTableProps> = ({
     );
 
     const exportDisabled = React.useMemo(() => {
+        void historyVersion;
         const history = historyRef.current;
         for (const row of sortedRows) {
             if ((history.get(row.key) ?? []).length > 0) {

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -1,95 +1,431 @@
 import React from 'react';
-import { Label } from '@patternfly/react-core';
+import {
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateHeader,
+    EmptyStateIcon,
+    FormSelect,
+    FormSelectOption,
+    Label,
+    Toolbar,
+    ToolbarContent,
+    ToolbarGroup,
+    ToolbarItem,
+    Tooltip,
+} from '@patternfly/react-core';
+import { DownloadIcon, OutlinedStarIcon, SearchIcon, StarIcon } from '@patternfly/react-icons';
 
-import { Reading, SensorChipGroup } from '../types/sensors';
+import { Sparkline } from './Sparkline';
+import { calcStats, pushSample, Sample } from '../lib/history';
+import type { TemperatureUnit } from '../hooks/useSensorPreferences';
+import { SENSOR_REFRESH_OPTIONS } from '../hooks/useSensorPreferences';
+import { convertForDisplay, displayUnitFor, formatMeasurement } from '../utils/units';
+import { buildHistoryCsv, HistorySeries } from '../utils/csv';
+import { getThresholdState } from '../utils/thresholds';
 import { _ } from '../utils/cockpit';
-
-export interface SensorTableProps {
-    groups: SensorChipGroup[];
-}
-
-interface TableRow {
-    key: string;
-    chip: string;
-    reading: Reading;
-    source?: string;
-}
+import type { SensorCategory, SensorChipGroup } from '../types/sensors';
 
 const MISSING_VALUE = '—';
 
-const formatValue = (value: number | undefined, unit?: string) => {
-    if (typeof value !== 'number') {
+type TableRow = {
+    key: string;
+    chip: string;
+    chipId: string;
+    readingLabel: string;
+    readingUnit?: string;
+    input: number;
+    source?: string;
+    reading: SensorChipGroup['readings'][number];
+};
+
+interface PreparedRow extends TableRow {
+    history: Sample[];
+    sessionStats: ReturnType<typeof calcStats>;
+    threshold: ReturnType<typeof getThresholdState>;
+    isPinned: boolean;
+}
+
+const ZERO_STATES: Record<SensorCategory, { title: string; description: string }> = {
+    temperature: {
+        title: _('No temperature sensors detected'),
+        description: _('Cockpit did not receive any temperature readings for this system.'),
+    },
+    fan: {
+        title: _('No fan telemetry available'),
+        description: _('The hardware monitoring stack did not expose any fan speed sensors.'),
+    },
+    voltage: {
+        title: _('No voltage sensors reported'),
+        description: _('No voltage inputs were reported by the available sensor backends.'),
+    },
+    power: {
+        title: _('No power sensors found'),
+        description: _('Power metrics were not exposed for this host or backend.'),
+    },
+    unknown: {
+        title: _('No miscellaneous sensors captured'),
+        description: _('Sensors outside the dedicated categories are not reporting data.'),
+    },
+};
+
+export interface SensorTableProps {
+    groups: SensorChipGroup[];
+    category: SensorCategory;
+    unit: TemperatureUnit;
+    onUnitChange: (unit: TemperatureUnit) => void;
+    refreshMs: number;
+    onRefreshChange: (value: number) => void;
+    pinnedKeys: readonly string[];
+    onTogglePinned: (key: string) => void;
+}
+
+const formatValue = (value: number | undefined, unit: string | undefined, preference: TemperatureUnit) => {
+    if (!Number.isFinite(value)) {
         return MISSING_VALUE;
     }
 
-    const formatter = new Intl.NumberFormat(undefined, {
-        maximumFractionDigits: Math.abs(value) < 10 ? 2 : 1,
-        minimumFractionDigits: 0,
-    });
-
-    const formatted = formatter.format(value);
-    return unit ? `${formatted} ${unit}` : formatted;
+    const converted = convertForDisplay(value, unit, preference);
+    const formatted = formatMeasurement(converted);
+    const displayUnit = displayUnitFor(unit, preference);
+    return displayUnit ? `${formatted} ${displayUnit}` : formatted;
 };
 
-export const SensorTable: React.FC<SensorTableProps> = ({ groups }) => {
+const formatStats = (
+    stats: ReturnType<typeof calcStats>,
+    unit: string | undefined,
+    preference: TemperatureUnit,
+): string => {
+    if (stats.n === 0) {
+        return MISSING_VALUE;
+    }
+
+    const min = formatMeasurement(convertForDisplay(stats.min, unit, preference));
+    const avg = formatMeasurement(convertForDisplay(stats.avg, unit, preference));
+    const max = formatMeasurement(convertForDisplay(stats.max, unit, preference));
+    const displayUnit = displayUnitFor(unit, preference);
+    const joined = `${min} / ${avg} / ${max}`;
+    return displayUnit ? `${joined} ${displayUnit}` : joined;
+};
+
+const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+export const SensorTable: React.FC<SensorTableProps> = ({
+    groups,
+    category,
+    unit,
+    onUnitChange,
+    refreshMs,
+    onRefreshChange,
+    pinnedKeys,
+    onTogglePinned,
+}) => {
+    const historyRef = React.useRef(new Map<string, Sample[]>());
+    const [historyVersion, setHistoryVersion] = React.useState(0);
+
+    const pinnedIndex = React.useMemo(() => {
+        const index = new Map<string, number>();
+        pinnedKeys.forEach((key, position) => {
+            index.set(key, position);
+        });
+        return index;
+    }, [pinnedKeys]);
+
     const rows = React.useMemo<TableRow[]>(
         () =>
             groups.flatMap(group =>
-                group.readings.map((reading, index) => ({
-                    key: `${group.id}-${index}`,
+                group.readings.map(reading => ({
+                    key: `${group.id}:${reading.label}`,
                     chip: group.label,
-                    reading,
+                    chipId: group.id,
+                    readingLabel: reading.label,
+                    readingUnit: reading.unit,
+                    input: reading.input,
                     source: group.source,
+                    reading,
                 })),
             ),
         [groups],
     );
 
-    return (
-        <div className="pf-c-table-wrapper" data-component="sensor-table">
-            <table className="pf-c-table pf-m-compact pf-m-grid-md" role="grid" aria-label={_('Sensor readings')}>
-                <thead>
-                    <tr>
-                        <th scope="col">{_('Chip')}</th>
-                        <th scope="col">{_('Sensor')}</th>
-                        <th scope="col">{_('Input')}</th>
-                        <th scope="col">{_('Minimum')}</th>
-                        <th scope="col">{_('Maximum')}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {rows.length === 0 ? (
-                        <tr>
-                            <td colSpan={5}>{_('No sensor data available yet.')}</td>
-                        </tr>
-                    ) : (
-                        rows.map(row => {
-                            const { reading } = row;
-                            const exceedsMax = typeof reading.max === 'number' && reading.input > reading.max;
-                            const rowClassName = exceedsMax ? 'pf-m-danger' : undefined;
+    const sortedRows = React.useMemo<PreparedRow[]>(() => {
+        const pinnedSet = new Set(pinnedKeys);
+        const history = historyRef.current;
+        return rows
+                .map(row => ({
+                    ...row,
+                    history: history.get(row.key) ?? [],
+                    sessionStats: calcStats(history.get(row.key) ?? []),
+                    threshold: getThresholdState(row.reading),
+                    isPinned: pinnedSet.has(row.key),
+                }))
+                .sort((a, b) => {
+                    const aPinned = pinnedSet.has(a.key);
+                    const bPinned = pinnedSet.has(b.key);
+                    if (aPinned && bPinned) {
+                        const orderA = pinnedIndex.get(a.key) ?? 0;
+                        const orderB = pinnedIndex.get(b.key) ?? 0;
+                        return orderA - orderB;
+                    }
+                    if (aPinned) {
+                        return -1;
+                    }
+                    if (bPinned) {
+                        return 1;
+                    }
 
-                            return (
-                                <tr key={row.key} className={rowClassName}>
-                                    <td data-label={_('Chip')}>
-                                        <span className="sensor-chip">
-                                            <span>{row.chip}</span>
-                                            {row.source && (
-                                                <Label color="grey" isCompact>
-                                                    {row.source}
-                                                </Label>
-                                            )}
-                                        </span>
-                                    </td>
-                                    <td data-label={_('Sensor')}>{reading.label}</td>
-                                    <td data-label={_('Input')}>{formatValue(reading.input, reading.unit)}</td>
-                                    <td data-label={_('Minimum')}>{formatValue(reading.min, reading.unit)}</td>
-                                    <td data-label={_('Maximum')}>{formatValue(reading.max, reading.unit)}</td>
-                                </tr>
-                            );
-                        })
-                    )}
-                </tbody>
-            </table>
+                    const chipCompare = collator.compare(a.chip, b.chip);
+                    if (chipCompare !== 0) {
+                        return chipCompare;
+                    }
+                    return collator.compare(a.readingLabel, b.readingLabel);
+                });
+    }, [rows, pinnedKeys, pinnedIndex, historyVersion]);
+
+    React.useEffect(() => {
+        const history = historyRef.current;
+        const activeKeys = new Set<string>();
+        let changed = false;
+
+        for (const row of rows) {
+            activeKeys.add(row.key);
+            if (!Number.isFinite(row.input)) {
+                continue;
+            }
+
+            const buffer = history.get(row.key) ?? [];
+            const previousLength = buffer.length;
+            pushSample(buffer, row.input);
+            if (!history.has(row.key)) {
+                history.set(row.key, buffer);
+            }
+            if (buffer.length !== previousLength) {
+                changed = true;
+            }
+        }
+
+        for (const key of Array.from(history.keys())) {
+            if (!activeKeys.has(key)) {
+                history.delete(key);
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            setHistoryVersion(version => version + 1);
+        }
+    }, [rows]);
+
+    const handleRefreshChange = React.useCallback(
+        (value: string) => {
+            const parsed = Number.parseInt(value, 10);
+            onRefreshChange(Number.isFinite(parsed) ? parsed : refreshMs);
+        },
+        [onRefreshChange, refreshMs],
+    );
+
+    const handleExport = React.useCallback(() => {
+        if (typeof document === 'undefined') {
+            return;
+        }
+
+        const history = historyRef.current;
+        const series: HistorySeries[] = [];
+
+        for (const row of sortedRows) {
+            const buffer = history.get(row.key);
+            if (!buffer || buffer.length === 0) {
+                continue;
+            }
+
+            const displayHistory = buffer.map(sample => ({
+                t: sample.t,
+                v: convertForDisplay(sample.v, row.readingUnit, unit),
+            }));
+
+            const labelUnit = displayUnitFor(row.readingUnit, unit);
+            const label = labelUnit
+                ? `${row.chip} — ${row.readingLabel} (${labelUnit})`
+                : `${row.chip} — ${row.readingLabel}`;
+
+            series.push({ key: row.key, label, history: displayHistory });
+        }
+
+        if (series.length === 0) {
+            return;
+        }
+
+        const csv = buildHistoryCsv(series);
+        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+        const url = URL.createObjectURL(blob);
+
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = 'sensors.csv';
+        anchor.style.display = 'none';
+        document.body.appendChild(anchor);
+        anchor.click();
+        document.body.removeChild(anchor);
+        URL.revokeObjectURL(url);
+    }, [sortedRows, unit, historyVersion]);
+
+    const handleUnitToggle = React.useCallback(
+        (nextUnit: TemperatureUnit) => {
+            onUnitChange(nextUnit);
+        },
+        [onUnitChange],
+    );
+
+    const exportDisabled = React.useMemo(() => {
+        const history = historyRef.current;
+        for (const row of sortedRows) {
+            if ((history.get(row.key) ?? []).length > 0) {
+                return false;
+            }
+        }
+        return true;
+    }, [sortedRows, historyVersion]);
+
+    const zeroState = ZERO_STATES[category] ?? ZERO_STATES.unknown;
+
+    return (
+        <div className="sensor-table" data-component="sensor-table">
+            <Toolbar className="sensor-toolbar" role="region" aria-label={_('Sensor table controls')}>
+                <ToolbarContent>
+                    <ToolbarGroup>
+                        <ToolbarItem>
+                            <label className="sensor-toolbar__label" htmlFor="sensor-refresh-select">
+                                {_('Refresh interval')}
+                            </label>
+                            <FormSelect
+                                value={String(refreshMs)}
+                                onChange={handleRefreshChange}
+                                aria-label={_('Refresh interval selector')}
+                                id="sensor-refresh-select"
+                            >
+                                {SENSOR_REFRESH_OPTIONS.map(option => (
+                                    <FormSelectOption
+                                        key={option}
+                                        value={option}
+                                        label={option === 10000 ? _('Every 10 seconds') : option === 5000 ? _('Every 5 seconds') : _('Every 2 seconds')}
+                                    />
+                                ))}
+                            </FormSelect>
+                        </ToolbarItem>
+                    </ToolbarGroup>
+                    <ToolbarGroup>
+                        <ToolbarItem>
+                            <label className="sensor-toolbar__label" htmlFor="sensor-unit-select">
+                                {_('Temperature unit')}
+                            </label>
+                            <FormSelect
+                                value={unit}
+                                onChange={value => handleUnitToggle(value as TemperatureUnit)}
+                                aria-label={_('Temperature unit selector')}
+                                id="sensor-unit-select"
+                            >
+                                <FormSelectOption value="C" label={_('Degrees Celsius (°C)')} />
+                                <FormSelectOption value="F" label={_('Degrees Fahrenheit (°F)')} />
+                            </FormSelect>
+                        </ToolbarItem>
+                    </ToolbarGroup>
+                    <ToolbarItem alignment={{ default: 'alignRight' }}>
+                        <Tooltip content={_('Download session history as CSV')}>
+                            <Button
+                                onClick={handleExport}
+                                variant="secondary"
+                                icon={<DownloadIcon />}
+                                isDisabled={exportDisabled}
+                            >
+                                {_('Export CSV')}
+                            </Button>
+                        </Tooltip>
+                    </ToolbarItem>
+                </ToolbarContent>
+            </Toolbar>
+
+            {sortedRows.length === 0 ? (
+                <div className="sensor-zero-state">
+                    <EmptyState variant="sm">
+                        <EmptyStateHeader
+                            icon={<EmptyStateIcon icon={SearchIcon} />}
+                            titleText={zeroState.title}
+                            headingLevel="h3"
+                        />
+                        <EmptyStateBody>{zeroState.description}</EmptyStateBody>
+                    </EmptyState>
+                </div>
+            ) : (
+                <div className="pf-c-table-wrapper" role="presentation">
+                    <table className="pf-c-table pf-m-compact pf-m-grid-md" role="grid" aria-label={_('Sensor readings')}>
+                        <thead>
+                            <tr>
+                                <th scope="col" aria-label={_('Pinned status')} />
+                                <th scope="col">{_('Chip')}</th>
+                                <th scope="col">{_('Sensor')}</th>
+                                <th scope="col">{_('Input')}</th>
+                                <th scope="col">{_('Session min/avg/max')}</th>
+                                <th scope="col">{_('Trend')}</th>
+                                <th scope="col">{_('Source')}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {sortedRows.map(row => {
+                                const history = historyRef.current.get(row.key) ?? [];
+                                const sparklineData = history.map(sample => ({
+                                    t: sample.t,
+                                    v: convertForDisplay(sample.v, row.readingUnit, unit),
+                                }));
+
+                                return (
+                                    <tr key={row.key}>
+                                        <td data-label={_('Pinned status')}>
+                                            <Tooltip
+                                                content={row.isPinned ? _('Unpin sensor') : _('Pin sensor')}
+                                                entryDelay={300}
+                                            >
+                                                <Button
+                                                    variant="plain"
+                                                    onClick={() => onTogglePinned(row.key)}
+                                                    aria-label={row.isPinned ? _('Unpin sensor') : _('Pin sensor')}
+                                                    data-testid="sensor-pin-toggle"
+                                                >
+                                                    {row.isPinned ? <StarIcon /> : <OutlinedStarIcon />}
+                                                </Button>
+                                            </Tooltip>
+                                        </td>
+                                        <td data-label={_('Chip')}>
+                                            <span className="sensor-chip">
+                                                <span>{row.chip}</span>
+                                                {row.source && (
+                                                    <Label color="grey" isCompact>
+                                                        {row.source}
+                                                    </Label>
+                                                )}
+                                            </span>
+                                        </td>
+                                        <td data-label={_('Sensor')}>{row.readingLabel}</td>
+                                        <td data-label={_('Input')}>
+                                            <span className={`sensor-reading sensor-reading--${row.threshold}`}>
+                                                {formatValue(row.input, row.readingUnit, unit)}
+                                            </span>
+                                        </td>
+                                        <td data-label={_('Session min/avg/max')}>
+                                            <span className="sensor-reading">
+                                                {formatStats(row.sessionStats, row.readingUnit, unit)}
+                                            </span>
+                                        </td>
+                                        <td data-label={_('Trend')}>
+                                            <Sparkline data={sparklineData} />
+                                        </td>
+                                        <td data-label={_('Source')}>{row.source ?? MISSING_VALUE}</td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/Sparkline.tsx
+++ b/src/components/Sparkline.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import type { Sample } from '../lib/history';
+
+export interface SparklineProps {
+    data: Sample[];
+    width?: number;
+    height?: number;
+}
+
+export const Sparkline: React.FC<SparklineProps> = ({ data, width = 140, height = 32 }) => {
+    if (!data.length) {
+        return <svg role="img" width={width} height={height} aria-hidden="true" />;
+    }
+
+    const values = data.map(sample => sample.v);
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    const range = max - min || 1;
+
+    const points = data
+            .map((sample, index) => {
+                const x = (index / Math.max(data.length - 1, 1)) * (width - 2) + 1;
+                const normalised = (sample.v - min) / range;
+                const y = height - 1 - normalised * (height - 2);
+                return `${x},${y}`;
+            })
+            .join(' ');
+
+    return (
+        <svg role="img" width={width} height={height} aria-hidden="true">
+            <polyline fill="none" stroke="currentColor" strokeWidth={1} points={points} vectorEffect="non-scaling-stroke" />
+        </svg>
+    );
+};

--- a/src/hooks/useSensorPreferences.ts
+++ b/src/hooks/useSensorPreferences.ts
@@ -1,0 +1,163 @@
+import React from 'react';
+
+export type TemperatureUnit = 'C' | 'F';
+
+const DEFAULT_UNIT: TemperatureUnit = 'C';
+const DEFAULT_REFRESH_MS = 5000;
+const REFRESH_CHOICES = new Set([2000, 5000, 10000]);
+
+const STORAGE_KEYS = {
+    unit: 'sensors.unit',
+    refresh: 'sensors.refreshMs',
+    pinned: 'sensors.pinned',
+} as const;
+
+const safeLocalStorage = (): Storage | undefined => {
+    if (typeof window === 'undefined') {
+        return undefined;
+    }
+
+    try {
+        return window.localStorage;
+    } catch {
+        return undefined;
+    }
+};
+
+const readNumber = (value: string | null, fallback: number): number => {
+    if (!value) {
+        return fallback;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed)) {
+        return fallback;
+    }
+
+    return REFRESH_CHOICES.has(parsed) ? parsed : fallback;
+};
+
+const readUnit = (value: string | null): TemperatureUnit => {
+    return value === 'F' ? 'F' : DEFAULT_UNIT;
+};
+
+const readPinned = (value: string | null): string[] => {
+    if (!value) {
+        return [];
+    }
+
+    try {
+        const parsed = JSON.parse(value);
+        if (Array.isArray(parsed)) {
+            return parsed.filter(entry => typeof entry === 'string');
+        }
+    } catch {
+        // Ignore malformed entries and fall back to the default.
+    }
+
+    return [];
+};
+
+const writeStorage = (key: string, value: string): void => {
+    const storage = safeLocalStorage();
+    if (!storage) {
+        return;
+    }
+
+    try {
+        storage.setItem(key, value);
+    } catch {
+        // Ignore quota errors and continue without persistence.
+    }
+};
+
+const removeStorage = (key: string): void => {
+    const storage = safeLocalStorage();
+    if (!storage) {
+        return;
+    }
+
+    try {
+        storage.removeItem(key);
+    } catch {
+        // Ignore failures.
+    }
+};
+
+export interface SensorPreferences {
+    unit: TemperatureUnit;
+    setUnit: (unit: TemperatureUnit) => void;
+    refreshMs: number;
+    setRefreshMs: (value: number) => void;
+    pinned: readonly string[];
+    togglePinned: (key: string) => void;
+    setPinned: (keys: readonly string[]) => void;
+}
+
+export const useSensorPreferences = (): SensorPreferences => {
+    const [unit, setUnitState] = React.useState<TemperatureUnit>(() => {
+        const storage = safeLocalStorage();
+        return readUnit(storage?.getItem(STORAGE_KEYS.unit) ?? null);
+    });
+
+    const [refreshMs, setRefreshState] = React.useState<number>(() => {
+        const storage = safeLocalStorage();
+        return readNumber(storage?.getItem(STORAGE_KEYS.refresh) ?? null, DEFAULT_REFRESH_MS);
+    });
+
+    const [pinned, setPinnedState] = React.useState<string[]>(() => {
+        const storage = safeLocalStorage();
+        return readPinned(storage?.getItem(STORAGE_KEYS.pinned) ?? null);
+    });
+
+    const setUnit = React.useCallback((next: TemperatureUnit) => {
+        setUnitState(next);
+        writeStorage(STORAGE_KEYS.unit, next);
+    }, []);
+
+    const setRefreshMs = React.useCallback((value: number) => {
+        const normalised = REFRESH_CHOICES.has(value) ? value : DEFAULT_REFRESH_MS;
+        setRefreshState(normalised);
+        writeStorage(STORAGE_KEYS.refresh, String(normalised));
+    }, []);
+
+    const setPinned = React.useCallback((keys: readonly string[]) => {
+        const unique = Array.from(new Set(keys));
+        setPinnedState(unique);
+        if (unique.length === 0) {
+            removeStorage(STORAGE_KEYS.pinned);
+            return;
+        }
+
+        writeStorage(STORAGE_KEYS.pinned, JSON.stringify(unique));
+    }, []);
+
+    const togglePinned = React.useCallback(
+        (key: string) => {
+            setPinnedState(prev => {
+                const exists = prev.includes(key);
+                const next = exists ? prev.filter(entry => entry !== key) : [...prev, key];
+                if (next.length === 0) {
+                    removeStorage(STORAGE_KEYS.pinned);
+                } else {
+                    writeStorage(STORAGE_KEYS.pinned, JSON.stringify(next));
+                }
+                return next;
+            });
+        },
+        [],
+    );
+
+    return {
+        unit,
+        setUnit,
+        refreshMs,
+        setRefreshMs,
+        pinned,
+        togglePinned,
+        setPinned,
+    };
+};
+
+export const SENSOR_REFRESH_OPTIONS = Array.from(REFRESH_CHOICES.values()).sort((a, b) => a - b);
+export const DEFAULT_SENSOR_REFRESH_MS = DEFAULT_REFRESH_MS;

--- a/src/hooks/useSensorPreferences.ts
+++ b/src/hooks/useSensorPreferences.ts
@@ -47,7 +47,7 @@ const readPinned = (value: string | null): string[] => {
     }
 
     try {
-        const parsed = JSON.parse(value);
+        const parsed: unknown = JSON.parse(value);
         if (Array.isArray(parsed)) {
             return parsed.filter(entry => typeof entry === 'string');
         }

--- a/src/lib/__tests__/history.test.ts
+++ b/src/lib/__tests__/history.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { calcStats, pushSample } from '../history';
+
+describe('history helpers', () => {
+    it('appends samples and respects the limit', () => {
+        const buffer: Array<{ t: number; v: number }> = [];
+        for (let index = 0; index < 5; index += 1) {
+            pushSample(buffer, index, 3);
+        }
+
+        expect(buffer).toHaveLength(3);
+        expect(buffer.map(sample => sample.v)).toEqual([2, 3, 4]);
+    });
+
+    it('calculates statistics for samples', () => {
+        const now = Date.now();
+        const buffer = [
+            { t: now, v: 10 },
+            { t: now + 1, v: 20 },
+            { t: now + 2, v: 30 },
+        ];
+
+        const stats = calcStats(buffer);
+        expect(stats).toEqual({ min: 10, max: 30, avg: 20, n: 3 });
+    });
+
+    it('returns NaN stats for empty buffers', () => {
+        const stats = calcStats([]);
+        expect(stats.n).toBe(0);
+        expect(Number.isNaN(stats.min)).toBe(true);
+        expect(Number.isNaN(stats.max)).toBe(true);
+        expect(Number.isNaN(stats.avg)).toBe(true);
+    });
+});

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,33 @@
+export type Sample = { t: number; v: number };
+export type Stats = { min: number; max: number; avg: number; n: number };
+
+export const MAX_HISTORY_SAMPLES = 300;
+
+export function pushSample(buffer: Sample[], value: number, limit = MAX_HISTORY_SAMPLES): void {
+    buffer.push({ t: Date.now(), v: value });
+    if (buffer.length > limit) {
+        buffer.splice(0, buffer.length - limit);
+    }
+}
+
+export function calcStats(buffer: Sample[]): Stats {
+    if (buffer.length === 0) {
+        return { min: Number.NaN, max: Number.NaN, avg: Number.NaN, n: 0 };
+    }
+
+    let min = Number.POSITIVE_INFINITY;
+    let max = Number.NEGATIVE_INFINITY;
+    let sum = 0;
+
+    for (const { v } of buffer) {
+        if (v < min) {
+            min = v;
+        }
+        if (v > max) {
+            max = v;
+        }
+        sum += v;
+    }
+
+    return { min, max, avg: sum / buffer.length, n: buffer.length };
+}

--- a/src/lib/providers/lm-sensors.ts
+++ b/src/lib/providers/lm-sensors.ts
@@ -301,9 +301,10 @@ export class LmSensorsProvider implements Provider {
         void poll();
 
         if (typeof window !== 'undefined') {
+            const interval = context?.refreshIntervalMs ?? POLL_INTERVAL_MS;
             this.intervalHandle = window.setInterval(() => {
                 void poll();
-            }, POLL_INTERVAL_MS);
+            }, interval);
         }
 
         return () => {

--- a/src/lib/providers/nvme.ts
+++ b/src/lib/providers/nvme.ts
@@ -237,9 +237,10 @@ export class NvmeProvider implements Provider {
         void poll();
 
         if (typeof window !== 'undefined') {
+            const interval = context?.refreshIntervalMs ?? POLL_INTERVAL_MS;
             this.intervalHandle = window.setInterval(() => {
                 void poll();
-            }, POLL_INTERVAL_MS);
+            }, interval);
         }
 
         return () => {

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -33,6 +33,7 @@ export class ProviderError extends Error {
 
 export interface ProviderContext {
     onError?: (error: ProviderError) => void;
+    refreshIntervalMs?: number;
 }
 
 export interface Provider {

--- a/src/utils/__tests__/csv.test.ts
+++ b/src/utils/__tests__/csv.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildHistoryCsv } from '../csv';
+
+const mockDate = new Date('2024-01-01T00:00:00.000Z').valueOf();
+
+describe('CSV exporter', () => {
+    it('builds a CSV table with aligned samples', () => {
+        const csv = buildHistoryCsv([
+            {
+                key: 'sensor-a',
+                label: 'Sensor A',
+                history: [
+                    { t: mockDate, v: 1 },
+                    { t: mockDate + 1000, v: 2 },
+                ],
+            },
+            {
+                key: 'sensor-b',
+                label: 'Sensor B',
+                history: [{ t: mockDate, v: 10 }],
+            },
+        ]);
+
+        const lines = csv.split('\n');
+        expect(lines[0]).toBe('ts,Sensor A,Sensor B');
+        expect(lines[1]).toBe('2024-01-01T00:00:00.000Z,1,10');
+        expect(lines[2]).toBe('2024-01-01T00:00:01.000Z,2,');
+    });
+
+    it('returns only the header when there is no data', () => {
+        expect(buildHistoryCsv([])).toBe('ts');
+    });
+});

--- a/src/utils/__tests__/thresholds.test.ts
+++ b/src/utils/__tests__/thresholds.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Reading } from '../../types/sensors';
+import { getThresholdState } from '../thresholds';
+
+describe('threshold evaluation', () => {
+    const baseReading: Reading = {
+        label: 'CPU Temp',
+        input: 60,
+        unit: '°C',
+        max: 80,
+        critical: 90,
+    };
+
+    it('returns normal when no thresholds are crossed', () => {
+        expect(getThresholdState({ ...baseReading, input: 40 })).toBe('normal');
+    });
+
+    it('returns warning when approaching the high threshold', () => {
+        expect(getThresholdState({ ...baseReading, input: 76 })).toBe('warning');
+    });
+
+    it('returns danger when high threshold is crossed', () => {
+        expect(getThresholdState({ ...baseReading, input: 82 })).toBe('danger');
+    });
+
+    it('returns danger when critical threshold is crossed', () => {
+        expect(getThresholdState({ ...baseReading, input: 95 })).toBe('danger');
+    });
+});

--- a/src/utils/__tests__/units.test.ts
+++ b/src/utils/__tests__/units.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { convertForDisplay, convertTemperature, displayUnitFor } from '../units';
+
+describe('unit helpers', () => {
+    it('converts Celsius to Fahrenheit', () => {
+        expect(convertTemperature(0, 'F')).toBeCloseTo(32);
+        expect(convertTemperature(100, 'F')).toBeCloseTo(212);
+    });
+
+    it('keeps Celsius when preference is Celsius', () => {
+        expect(convertForDisplay(25, '°C', 'C')).toBeCloseTo(25);
+    });
+
+    it('converts display units according to preference', () => {
+        expect(convertForDisplay(25, '°C', 'F')).toBeCloseTo(77);
+        expect(displayUnitFor('°C', 'F')).toBe('°F');
+        expect(displayUnitFor('RPM', 'F')).toBe('RPM');
+    });
+});

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,0 +1,43 @@
+import type { Sample } from '../lib/history';
+
+export interface HistorySeries {
+    key: string;
+    label: string;
+    history: Sample[];
+}
+
+const escapeCell = (value: string): string => {
+    if (/[",\n]/.test(value)) {
+        return `"${value.replace(/"/g, '""')}"`;
+    }
+
+    return value;
+};
+
+export const buildHistoryCsv = (series: HistorySeries[]): string => {
+    const headers = ['ts', ...series.map(item => escapeCell(item.label))];
+    const maxLength = Math.max(0, ...series.map(item => item.history.length));
+
+    const rows: string[] = [headers.join(',')];
+
+    for (let index = 0; index < maxLength; index += 1) {
+        let timestamp = '';
+        const values: string[] = [];
+
+        for (const item of series) {
+            const sample = item.history[index];
+            if (sample) {
+                if (!timestamp) {
+                    timestamp = new Date(sample.t).toISOString();
+                }
+                values.push(escapeCell(String(sample.v)));
+            } else {
+                values.push('');
+            }
+        }
+
+        rows.push([timestamp, ...values].join(','));
+    }
+
+    return rows.join('\n');
+};

--- a/src/utils/thresholds.ts
+++ b/src/utils/thresholds.ts
@@ -1,0 +1,28 @@
+import type { Reading } from '../types/sensors';
+import { CELSIUS_UNIT } from './units';
+
+export type ThresholdState = 'normal' | 'warning' | 'danger';
+
+const WARNING_MARGIN_CELSIUS = 5;
+
+export const getThresholdState = (reading: Reading): ThresholdState => {
+    const { input, max: high, critical } = reading;
+
+    if (typeof input !== 'number') {
+        return 'normal';
+    }
+
+    if (typeof critical === 'number' && input >= critical) {
+        return 'danger';
+    }
+
+    if (typeof high === 'number' && input >= high) {
+        return 'danger';
+    }
+
+    if (typeof high === 'number' && reading.unit === CELSIUS_UNIT && input >= high - WARNING_MARGIN_CELSIUS) {
+        return 'warning';
+    }
+
+    return 'normal';
+};

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -1,0 +1,50 @@
+import type { TemperatureUnit } from '../hooks/useSensorPreferences';
+
+export const CELSIUS_UNIT = '°C';
+export const FAHRENHEIT_UNIT = '°F';
+
+export const convertTemperature = (value: number, unit: TemperatureUnit): number => {
+    if (unit === 'C') {
+        return value;
+    }
+
+    return value * (9 / 5) + 32;
+};
+
+export const normaliseTemperature = (value: number, unit: TemperatureUnit): number => {
+    if (unit === 'C') {
+        return value;
+    }
+
+    return (value - 32) * (5 / 9);
+};
+
+export const formatMeasurement = (value: number, options?: Intl.NumberFormatOptions): string => {
+    const formatter = new Intl.NumberFormat(undefined, {
+        maximumFractionDigits: Math.abs(value) < 10 ? 2 : 1,
+        minimumFractionDigits: 0,
+        ...options,
+    });
+
+    return formatter.format(value);
+};
+
+export const displayUnitFor = (unit: string | undefined, preference: TemperatureUnit): string | undefined => {
+    if (unit === CELSIUS_UNIT) {
+        return preference === 'F' ? FAHRENHEIT_UNIT : CELSIUS_UNIT;
+    }
+
+    return unit;
+};
+
+export const convertForDisplay = (
+    value: number,
+    unit: string | undefined,
+    preference: TemperatureUnit,
+): number => {
+    if (unit === CELSIUS_UNIT) {
+        return convertTemperature(value, preference);
+    }
+
+    return value;
+};


### PR DESCRIPTION
## Summary
- add per-sensor session history tracking with statistics, sparkline component, and CSV export helpers
- overhaul the sensor table UI to include toolbar controls, threshold highlighting, pinning, and zero-state handling
- persist user preferences, update application wiring, documentation, changelog, and add comprehensive test coverage

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e95b75cd38832899c38b6c52847b83