### PR TITLE
feat: expand sensors layout width

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -1,5 +1,23 @@
 @use "page";
 
+.sensor-page {
+    --pf-v6-c-page--section--m-width-limited--MaxWidth: none;
+}
+
+.pf-c-table-wrapper {
+    width: 100%;
+    overflow-x: auto;
+}
+
+.pf-c-table {
+    width: 100%;
+}
+
+.pf-c-table td,
+.pf-c-table th {
+    word-break: break-word;
+}
+
 .sensor-description p {
     font-weight: 600;
 }
@@ -31,6 +49,11 @@
 }
 
 .sensor-toolbar {
+    position: sticky;
+    top: 0;
+    z-index: var(--pf-global--ZIndex--md);
+    background: var(--pf-global--BackgroundColor--100);
+    padding-block: var(--pf-global--spacer--sm);
     margin-bottom: var(--pf-global--spacer--md);
 }
 

--- a/src/app/Application.tsx
+++ b/src/app/Application.tsx
@@ -177,7 +177,12 @@ export const Application: React.FC = () => {
 
     return (
         <Page>
-            <PageSection variant={PAGE_SECTION_VARIANT} isFilled isWidthLimited={false}>
+            <PageSection
+                variant={PAGE_SECTION_VARIANT}
+                isFilled
+                isWidthLimited={false}
+                className="sensor-page"
+            >
                 <div className="sensor-banner">{renderBanner()}</div>
                 <Tabs
                     activeKey={activeKey}

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -290,7 +290,11 @@ export const SensorTable: React.FC<SensorTableProps> = ({
 
     return (
         <div className="sensor-table" data-component="sensor-table">
-            <Toolbar className="sensor-toolbar" role="region" aria-label={_('Sensor table controls')}>
+            <Toolbar
+                className="sensor-toolbar"
+                role="region"
+                aria-label={_('Sensor table controls')}
+            >
                 <ToolbarContent>
                     <ToolbarGroup>
                         <ToolbarItem>


### PR DESCRIPTION
## Summary
- allow the sensors page section to span the full available width
- make the toolbar sticky and widen the table for improved usability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e9708f6a6c832882877afd95411981