### PR TITLE
CSP-safe CSV export and PFv6 zero-state compatibility

### DIFF
--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -3,7 +3,6 @@ import {
     Button,
     EmptyState,
     EmptyStateBody,
-    EmptyStateHeader,
     FormSelect,
     FormSelectOption,
     Label,
@@ -14,6 +13,7 @@ import {
     Tooltip,
 } from '@patternfly/react-core';
 import { DownloadIcon, OutlinedStarIcon, SearchIcon, StarIcon } from '@patternfly/react-icons';
+import { EmptyStateHeader } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateHeader';
 
 import { Sparkline } from './Sparkline';
 import { calcStats, pushSample, Sample } from '../lib/history';

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -3,6 +3,7 @@ import {
     Button,
     EmptyState,
     EmptyStateBody,
+    EmptyStateHeader,
     FormSelect,
     FormSelectOption,
     Label,
@@ -12,7 +13,6 @@ import {
     ToolbarItem,
     Tooltip,
 } from '@patternfly/react-core';
-import { EmptyStateHeader } from '@patternfly/react-core/dist/esm/components/EmptyState/EmptyStateHeader';
 import { DownloadIcon, OutlinedStarIcon, SearchIcon, StarIcon } from '@patternfly/react-icons';
 
 import { Sparkline } from './Sparkline';
@@ -24,6 +24,7 @@ import { buildHistoryCsv, HistorySeries } from '../utils/csv';
 import { getThresholdState } from '../utils/thresholds';
 import { _ } from '../utils/cockpit';
 import type { SensorCategory, SensorChipGroup } from '../types/sensors';
+import { saveTextFile } from '../utils/download';
 
 const MISSING_VALUE = '—';
 
@@ -224,20 +225,11 @@ export const SensorTable: React.FC<SensorTableProps> = ({
     );
 
     const handleExport = React.useCallback(() => {
-        if (typeof document === 'undefined') {
-            return;
-        }
-
         const history = historyRef.current;
-        const series: HistorySeries[] = [];
+        const series: HistorySeries[] = sortedRows.map(row => {
+            const buffer = history.get(row.key) ?? [];
 
-        for (const row of sortedRows) {
-            const buffer = history.get(row.key);
-            if (!buffer || buffer.length === 0) {
-                continue;
-            }
-
-            const displayHistory = buffer.map(sample => ({
+            const samples = buffer.map(sample => ({
                 t: sample.t,
                 v: convertForDisplay(sample.v, row.readingUnit, unit),
             }));
@@ -247,25 +239,20 @@ export const SensorTable: React.FC<SensorTableProps> = ({
                 ? `${row.chip} — ${row.readingLabel} (${labelUnit})`
                 : `${row.chip} — ${row.readingLabel}`;
 
-            series.push({ key: row.key, label, history: displayHistory });
-        }
+            return { key: row.key, label, samples };
+        });
 
         if (series.length === 0) {
             return;
         }
 
         const csv = buildHistoryCsv(series);
-        const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-        const url = URL.createObjectURL(blob);
-
-        const anchor = document.createElement('a');
-        anchor.href = url;
-        anchor.download = 'sensors.csv';
-        anchor.style.display = 'none';
-        document.body.appendChild(anchor);
-        anchor.click();
-        document.body.removeChild(anchor);
-        URL.revokeObjectURL(url);
+        const now = new Date();
+        const stamp =
+            `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}` +
+            `_${String(now.getHours()).padStart(2, '0')}${String(now.getMinutes()).padStart(2, '0')}${String(now.getSeconds()).padStart(2, '0')}`;
+        const filename = `cockpit-sensors_${stamp}.csv`;
+        saveTextFile(filename, csv, 'text/csv;charset=utf-8');
     }, [sortedRows, unit]);
 
     const handleUnitToggle = React.useCallback(
@@ -351,7 +338,7 @@ export const SensorTable: React.FC<SensorTableProps> = ({
             {sortedRows.length === 0 ? (
                 <div className="sensor-zero-state">
                     <EmptyState variant="sm">
-                        <EmptyStateHeader icon={SearchIcon} titleText={zeroState.title} headingLevel="h3" />
+                        <EmptyStateHeader icon={<SearchIcon />} titleText={zeroState.title} headingLevel="h3" />
                         <EmptyStateBody>{zeroState.description}</EmptyStateBody>
                     </EmptyState>
                 </div>

--- a/src/utils/__tests__/csv.test.ts
+++ b/src/utils/__tests__/csv.test.ts
@@ -10,7 +10,7 @@ describe('CSV exporter', () => {
             {
                 key: 'sensor-a',
                 label: 'Sensor A',
-                history: [
+                samples: [
                     { t: mockDate, v: 1 },
                     { t: mockDate + 1000, v: 2 },
                 ],
@@ -18,17 +18,17 @@ describe('CSV exporter', () => {
             {
                 key: 'sensor-b',
                 label: 'Sensor B',
-                history: [{ t: mockDate, v: 10 }],
+                samples: [{ t: mockDate, v: 10 }],
             },
         ]);
 
         const lines = csv.split('\n');
-        expect(lines[0]).toBe('ts,Sensor A,Sensor B');
+        expect(lines[0]).toBe('timestamp,Sensor A,Sensor B');
         expect(lines[1]).toBe('2024-01-01T00:00:00.000Z,1,10');
         expect(lines[2]).toBe('2024-01-01T00:00:01.000Z,2,');
     });
 
     it('returns only the header when there is no data', () => {
-        expect(buildHistoryCsv([])).toBe('ts');
+        expect(buildHistoryCsv([])).toBe('timestamp');
     });
 });

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -3,7 +3,7 @@ import type { Sample } from '../lib/history';
 export interface HistorySeries {
     key: string;
     label: string;
-    history: Sample[];
+    samples: Sample[];
 }
 
 const escapeCell = (value: string): string => {
@@ -15,8 +15,8 @@ const escapeCell = (value: string): string => {
 };
 
 export const buildHistoryCsv = (series: HistorySeries[]): string => {
-    const headers = ['ts', ...series.map(item => escapeCell(item.label))];
-    const maxLength = Math.max(0, ...series.map(item => item.history.length));
+    const headers = ['timestamp', ...series.map(item => escapeCell(item.label))];
+    const maxLength = Math.max(0, ...series.map(item => item.samples.length));
 
     const rows: string[] = [headers.join(',')];
 
@@ -25,7 +25,7 @@ export const buildHistoryCsv = (series: HistorySeries[]): string => {
         const values: string[] = [];
 
         for (const item of series) {
-            const sample = item.history[index];
+            const sample = item.samples[index];
             if (sample) {
                 if (!timestamp) {
                     timestamp = new Date(sample.t).toISOString();

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -1,0 +1,20 @@
+// Safe text file download that complies with Cockpit's default CSP (no inline scripts)
+export function saveTextFile(name: string, data: string, mime = 'text/plain;charset=utf-8'): void {
+    try {
+        const blob = new Blob([data], { type: mime });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement('a');
+        anchor.style.display = 'none';
+        anchor.href = url;
+        anchor.download = name;
+        anchor.rel = 'noopener';
+        document.body.appendChild(anchor);
+        anchor.click();
+        setTimeout(() => {
+            document.body.removeChild(anchor);
+            URL.revokeObjectURL(url);
+        }, 0);
+    } catch (error) {
+        console.error('Failed to save file:', error);
+    }
+}


### PR DESCRIPTION
## Summary
- add a CSP-compliant download utility and use it for timestamped CSV exports
- include all visible sensor series when building the CSV and update tests for the new format
- render the zero-state icon via PatternFly v6 exports to avoid runtime errors

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e978c922608328b999c9cc32debb29