### PR TITLE
fix(pf6): EmptyState icon and CSP-safe CSV export

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -4,12 +4,21 @@
     --pf-v6-c-page--section--m-width-limited--MaxWidth: none;
 }
 
+// Ensure the sensors table uses the available width while remaining scrollable when needed.
 .pf-c-table-wrapper {
     width: 100%;
     overflow-x: auto;
 }
 
 .pf-c-table {
+    width: 100%;
+}
+
+.pf-c-table.pf-m-compact {
+    min-width: 100%;
+}
+
+.sensor-zero-state {
     width: 100%;
 }
 


### PR DESCRIPTION
## Summary
- load the PatternFly search icon from the ESM bundle and pass the component to `EmptyStateHeader`
- replace the CSV export helper with a Blob/ObjectURL workflow that satisfies Cockpit CSP policies
- ensure the sensors table wrapper and empty state occupy the full width without layout regressions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e9c69876e88328b38204bcd77a67f9