### PR TITLE
fix: add sandbox-safe CSV export fallback

### DIFF
--- a/src/__mocks__/@patternfly/react-core.ts
+++ b/src/__mocks__/@patternfly/react-core.ts
@@ -21,6 +21,7 @@ export const AlertVariant = { info: 'info', warning: 'warning', danger: 'danger'
 export const Button = ({ children, isDisabled, ...props }: ComponentProps & { isDisabled?: boolean }) =>
     React.createElement('button', { ...props, disabled: isDisabled }, children);
 export const ClipboardCopy = ({ children }: ComponentProps) => React.createElement('pre', null, children);
+export const ClipboardCopyVariant = { expansion: 'expansion' } as const;
 export const Content = createElement('section');
 export const Label = ({ children, ...props }: ComponentProps & { isCompact?: boolean }) => {
     const { isCompact, ...rest } = props;
@@ -81,6 +82,24 @@ export const Toolbar = createElement('div');
 export const ToolbarContent = createElement('div');
 export const ToolbarGroup = createElement('div');
 export const ToolbarItem = createElement('div');
+
+export const ModalVariant = { medium: 'medium', small: 'small', large: 'large' } as const;
+export const Modal = ({
+    children,
+    isOpen = true,
+    actions,
+    ...props
+}: React.PropsWithChildren<{ isOpen?: boolean; actions?: React.ReactNode[] } & AnyProps>) => {
+    const { onClose, variant, title, description, ...rest } = props;
+    void onClose;
+    void variant;
+    void title;
+    void description;
+    if (!isOpen) {
+        return null;
+    }
+    return React.createElement('div', rest, children, actions);
+};
 
 interface FormSelectProps extends ComponentProps {
     value?: string;

--- a/src/app.scss
+++ b/src/app.scss
@@ -10,6 +10,10 @@
     overflow-x: auto;
 }
 
+.pf-c-toolbar {
+    max-width: 100%;
+}
+
 .pf-c-table {
     width: 100%;
 }


### PR DESCRIPTION
## Summary
- add a modal fallback that exposes CSV contents and supports copying when iframe downloads are blocked
- guard CSV exports against sandbox restrictions and refresh icon usage for PF v6 compatibility
- keep the sensors toolbar from shrinking by enforcing a full-width layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e9caf2458c83288e5b4446b5bbbde0