### PR TITLE
Add modal-based CSV export fallback

### DIFF
--- a/src/__mocks__/@patternfly/react-icons.ts
+++ b/src/__mocks__/@patternfly/react-icons.ts
@@ -7,6 +7,7 @@ const createIcon = (name: string) => {
 };
 
 export const DownloadIcon = createIcon('DownloadIcon');
+export const ClipboardIcon = createIcon('ClipboardIcon');
 export const OutlinedStarIcon = createIcon('OutlinedStarIcon');
 export const StarIcon = createIcon('StarIcon');
 export const SearchIcon = createIcon('SearchIcon');


### PR DESCRIPTION
## Summary
- add a sandbox-friendly export modal with copy and optional download actions to SensorTable
- provide a ClipboardIcon mock to keep tests passing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e9d5fd979c83289154b1387633bcd8