### PR TITLE
Sync plugin theme with Cockpit host frame

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -3,6 +3,9 @@
 /* Dark-theme ready: usa tokens PF v6 y NO colores hardcodeados */
 /* Variables de Sensors (se sobreescriben en tema oscuro automáticamente) */
 :root {
+    /* Permite a los controles nativos adoptar dark/light */
+    color-scheme: light dark;
+
     --sensor-sparkline-stroke: var(--pf-v6-global--palette--black-700);
     --sensor-sparkline-axis: var(--pf-v6-global--palette--black-400);
 }
@@ -43,6 +46,11 @@
 
 .pf-c-table {
     width: 100%;
+}
+
+/* Section clara/oscura según PF (no forzar colores fijos) */
+.pf-v6-c-page__main-section {
+    background: var(--pf-v6-global--BackgroundColor--100);
 }
 
 .pf-c-table.pf-m-compact {

--- a/src/app/Application.tsx
+++ b/src/app/Application.tsx
@@ -42,6 +42,7 @@ import { useSensorPreferences } from '../hooks/useSensorPreferences';
 import { SensorCategory } from '../types/sensors';
 import { groupsForCategory } from '../utils/grouping';
 import { _ } from '../utils/cockpit';
+import { syncWithParentPatternflyTheme } from '../lib/syncTheme';
 
 import '../app.scss';
 
@@ -84,6 +85,10 @@ const TABS: readonly TabDefinition[] = [
 ];
 
 export const Application: React.FC = () => {
+    React.useEffect(() => {
+        return syncWithParentPatternflyTheme();
+    }, []);
+
     const [activeKey, setActiveKey] = React.useState<number>(TABS[0].eventKey);
     const { unit, setUnit, refreshMs, setRefreshMs, pinned, togglePinned } = useSensorPreferences();
     const { data, isLoading, status, activeProvider, lastError, availableProviders, retry } = useSensors(refreshMs);

--- a/src/lib/syncTheme.ts
+++ b/src/lib/syncTheme.ts
@@ -10,34 +10,35 @@
  * Aquí observamos el <html> padre y reflejamos esa clase en el <html> local.
  */
 export function syncWithParentPatternflyTheme(): () => void {
-  try {
-    const selfRoot = document.documentElement;
-    const parentRoot = window.parent && window.parent !== window
-      ? window.parent.document.documentElement
-      : null;
+    try {
+        const selfRoot = document.documentElement;
+        const parentRoot =
+            window.parent && window.parent !== window ? window.parent.document.documentElement : null;
 
-    if (!parentRoot || parentRoot === selfRoot) {
-      return () => undefined;
+        if (!parentRoot || parentRoot === selfRoot) {
+            return () => undefined;
+        }
+
+        const THEMES = ['pf-v6-theme-dark', 'pf-v6-theme-light', 'pf-v6-theme-system'];
+
+        const apply = () => {
+            const parentTheme = Array.from(parentRoot.classList).find(c => THEMES.includes(c));
+            THEMES.forEach(c => selfRoot.classList.remove(c));
+            if (parentTheme) {
+                selfRoot.classList.add(parentTheme);
+            }
+        };
+
+        // Aplicación inicial
+        apply();
+
+        // Observa cambios del tema en caliente (cuando el usuario lo cambia)
+        const mo = new MutationObserver(apply);
+        mo.observe(parentRoot, { attributes: true, attributeFilter: ['class'] });
+
+        return () => mo.disconnect();
+    } catch {
+        // no-op: nunca tires la UI por tema
+        return () => undefined;
     }
-
-    const THEMES = ['pf-v6-theme-dark', 'pf-v6-theme-light', 'pf-v6-theme-system'];
-
-    const apply = () => {
-      const parentTheme = Array.from(parentRoot.classList).find(c => THEMES.includes(c));
-      THEMES.forEach(c => selfRoot.classList.remove(c));
-      if (parentTheme) selfRoot.classList.add(parentTheme);
-    };
-
-    // Aplicación inicial
-    apply();
-
-    // Observa cambios del tema en caliente (cuando el usuario lo cambia)
-    const mo = new MutationObserver(apply);
-    mo.observe(parentRoot, { attributes: true, attributeFilter: ['class'] });
-
-    return () => mo.disconnect();
-  } catch {
-    // no-op: nunca tires la UI por tema
-    return () => undefined;
-  }
 }

--- a/src/lib/syncTheme.ts
+++ b/src/lib/syncTheme.ts
@@ -1,0 +1,43 @@
+/**
+ * Sincroniza el tema PatternFly del iframe del plugin con el tema global
+ * aplicado por Cockpit en el documento padre.
+ *
+ * Cockpit añade una clase en <html>:
+ *   - pf-v6-theme-dark
+ *   - pf-v6-theme-light
+ *   - pf-v6-theme-system
+ *
+ * Aquí observamos el <html> padre y reflejamos esa clase en el <html> local.
+ */
+export function syncWithParentPatternflyTheme(): () => void {
+  try {
+    const selfRoot = document.documentElement;
+    const parentRoot = window.parent && window.parent !== window
+      ? window.parent.document.documentElement
+      : null;
+
+    if (!parentRoot || parentRoot === selfRoot) {
+      return () => undefined;
+    }
+
+    const THEMES = ['pf-v6-theme-dark', 'pf-v6-theme-light', 'pf-v6-theme-system'];
+
+    const apply = () => {
+      const parentTheme = Array.from(parentRoot.classList).find(c => THEMES.includes(c));
+      THEMES.forEach(c => selfRoot.classList.remove(c));
+      if (parentTheme) selfRoot.classList.add(parentTheme);
+    };
+
+    // Aplicación inicial
+    apply();
+
+    // Observa cambios del tema en caliente (cuando el usuario lo cambia)
+    const mo = new MutationObserver(apply);
+    mo.observe(parentRoot, { attributes: true, attributeFilter: ['class'] });
+
+    return () => mo.disconnect();
+  } catch {
+    // no-op: nunca tires la UI por tema
+    return () => undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- add a helper to mirror the host document PatternFly theme into the plugin iframe
- initialize the theme synchronizer from the application root so toggles are followed in real time
- adjust shared styles so native controls and sections track the active light or dark background tokens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ea9b90b0008328949774b5db4e63f2