### PR TITLE
fix: align sparkline styling with theme tokens

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -6,28 +6,15 @@
     /* Permite a los controles nativos adoptar dark/light */
     color-scheme: light dark;
 
-    --sensor-sparkline-stroke: var(--pf-v6-global--palette--black-700);
+    /* En claro: trazos oscuros y eje gris */
+    --sensor-sparkline-stroke: var(--pf-v6-global--palette--black-800);
     --sensor-sparkline-axis: var(--pf-v6-global--palette--black-400);
 }
 
 .pf-v6-theme-dark {
-    --sensor-sparkline-stroke: var(--pf-v6-global--palette--white-700);
-    --sensor-sparkline-axis: var(--pf-v6-global--palette--white-500);
-}
-
-.sensor-sparkline {
-    display: inline-block;
-    width: 140px;
-    height: 28px;
-}
-
-.sensor-sparkline path {
-    stroke: var(--sensor-sparkline-stroke);
-}
-
-.sensor-sparkline .axis {
-    stroke: var(--sensor-sparkline-axis);
-    opacity: .3;
+    /* En oscuro: trazos claros y eje gris claro (mejor contraste) */
+    --sensor-sparkline-stroke: var(--pf-v6-global--palette--white-600);
+    --sensor-sparkline-axis: var(--pf-v6-global--palette--white-400);
 }
 
 .sensor-page {

--- a/src/components/Sparkline.scss
+++ b/src/components/Sparkline.scss
@@ -1,0 +1,26 @@
+/* Sparkline listo para tema claro/oscuro (PatternFly v6) */
+.sensor-sparkline {
+    display: block;
+    background: transparent;            /* nada de fondo negro/blanco */
+    color: var(--sensor-sparkline-stroke);
+}
+
+/* El trazo de la serie hereda el color (currentColor) */
+.sensor-sparkline path,
+.sensor-sparkline polyline {
+    stroke: currentColor;
+    fill: none;
+    stroke-width: 1.5;
+    vector-effect: non-scaling-stroke;
+}
+
+/* Eje/base del sparkline (si se dibuja) */
+.sensor-sparkline line.axis,
+.sensor-sparkline .axis {
+    stroke: var(--sensor-sparkline-axis);
+}
+
+/* Por si hay un rectángulo de fondo en el SVG */
+.sensor-sparkline .bg {
+    fill: transparent;
+}

--- a/src/components/Sparkline.tsx
+++ b/src/components/Sparkline.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import './Sparkline.scss';
 
 import type { Sample } from '../lib/history';
 
@@ -29,13 +30,7 @@ export const Sparkline: React.FC<SparklineProps> = ({ data, width = 140, height 
 
     return (
         <svg role="img" className="sensor-sparkline" width={width} height={height} aria-hidden="true">
-            <polyline
-                fill="none"
-                stroke="var(--sensor-sparkline-stroke)"
-                strokeWidth={1}
-                points={points}
-                vectorEffect="non-scaling-stroke"
-            />
+            <polyline points={points} vectorEffect="non-scaling-stroke" />
         </svg>
     );
 };


### PR DESCRIPTION
## Summary
- move sparkline styling into a dedicated SCSS module that relies on PatternFly v6 tokens
- adjust sparkline component to consume the new styles and theme variables
- tune global sparkline CSS variables for improved contrast in light and dark themes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb08bc6da88328a39eed2522c8f336