### PR TITLE
Add watts tab with powercap sensor provider

### DIFF
--- a/src/__tests__/groups-for-category.test.ts
+++ b/src/__tests__/groups-for-category.test.ts
@@ -34,16 +34,13 @@ describe('groupsForCategory', () => {
         expect(groupsForCategory(groups, 'unknown')).toEqual(groups);
     });
 
-    it('includes power groups in the fallback tab', () => {
+    it('returns power groups when explicitly requested', () => {
         const groups: SensorChipGroup[] = [
             buildGroup('power-1', 'power'),
             buildGroup('unknown-1', 'unknown'),
             buildGroup('temp-1', 'temperature'),
         ];
 
-        expect(groupsForCategory(groups, 'unknown')).toEqual([
-            buildGroup('power-1', 'power'),
-            buildGroup('unknown-1', 'unknown'),
-        ]);
+        expect(groupsForCategory(groups, 'power')).toEqual([buildGroup('power-1', 'power')]);
     });
 });

--- a/src/__tests__/useSensors.helpers.test.ts
+++ b/src/__tests__/useSensors.helpers.test.ts
@@ -57,6 +57,18 @@ describe('useSensors helpers', () => {
                 unit: SENSOR_KIND_TO_UNIT.volt,
             },
             {
+                provider: 'powercap',
+                kind: 'power',
+                id: 'package-0:power',
+                label: 'Package-0',
+                value: 28.3,
+                chipId: 'package-0',
+                chipLabel: 'Package 0',
+                chipName: 'intel-rapl:0',
+                unit: SENSOR_KIND_TO_UNIT.power,
+                category: 'power',
+            },
+            {
                 provider: 'nvme',
                 kind: 'temp',
                 id: '/dev/nvme0:temperature',
@@ -69,7 +81,7 @@ describe('useSensors helpers', () => {
         ];
 
         const data = samplesToSensorData(samples);
-        expect(data.groups).toHaveLength(3);
+        expect(data.groups).toHaveLength(4);
 
         const cpuTemperature = data.groups.find(group => group.id === 'chip0:temperature');
         expect(cpuTemperature).toMatchObject({
@@ -82,6 +94,9 @@ describe('useSensors helpers', () => {
 
         const cpuVoltage = data.groups.find(group => group.id === 'chip0:voltage');
         expect(cpuVoltage?.readings[0]).toMatchObject({ label: '+12V', unit: SENSOR_KIND_TO_UNIT.volt });
+
+        const packagePower = data.groups.find(group => group.category === 'power');
+        expect(packagePower?.readings[0]).toMatchObject({ label: 'Package-0', unit: SENSOR_KIND_TO_UNIT.power });
 
         const nvmeGroup = data.groups.find(group => group.id?.startsWith('/dev/nvme0'));
         expect(nvmeGroup).toMatchObject({ source: 'nvme' });

--- a/src/app/Application.tsx
+++ b/src/app/Application.tsx
@@ -76,9 +76,15 @@ const TABS: readonly TabDefinition[] = [
     },
     {
         eventKey: 3,
+        title: _('Watts'),
+        description: _('Track system and package power usage as reported by available RAPL interfaces.'),
+        category: 'power',
+    },
+    {
+        eventKey: 4,
         title: _('Other sensors'),
         description: _(
-            'Access readings for sensors that are not recognised as temperature, fan, or voltage devices.'
+            'Access readings for sensors that are not recognised as temperature, fan, voltage, or power devices.'
         ),
         category: 'unknown',
     },

--- a/src/hooks/useSensors.ts
+++ b/src/hooks/useSensors.ts
@@ -246,7 +246,7 @@ export const useSensors = (refreshIntervalMs = DEFAULT_SENSOR_REFRESH_MS): UseSe
                 } catch (error) {
                     if (error instanceof ProviderError && error.code === 'permission-denied') {
                         handleProviderError(provider, error);
-                        return;
+                        continue;
                     }
                 }
             }

--- a/src/hooks/useSensors.ts
+++ b/src/hooks/useSensors.ts
@@ -5,6 +5,7 @@ import { DEFAULT_SENSOR_REFRESH_MS } from './useSensorPreferences';
 import { hwmonProvider } from '../lib/providers/hwmon';
 import { lmSensorsProvider } from '../lib/providers/lm-sensors';
 import { nvmeProvider } from '../lib/providers/nvme';
+import { powercapProvider } from '../lib/providers/powercap';
 import {
     Provider,
     ProviderError,
@@ -35,7 +36,7 @@ export interface UseSensorsResult extends UseSensorsState {
 }
 
 const PRIMARY_PROVIDERS: Provider[] = [hwmonProvider, lmSensorsProvider];
-const AUXILIARY_PROVIDERS: Provider[] = [nvmeProvider];
+const AUXILIARY_PROVIDERS: Provider[] = [powercapProvider, nvmeProvider];
 const AUXILIARY_PROVIDER_NAMES = new Set(AUXILIARY_PROVIDERS.map(provider => provider.name));
 const AGGREGATION_ORDER = PRIMARY_PROVIDERS.concat(AUXILIARY_PROVIDERS).map(provider => provider.name);
 

--- a/src/lib/providers/powercap.ts
+++ b/src/lib/providers/powercap.ts
@@ -1,0 +1,302 @@
+import { getCockpit } from '../../utils/cockpit';
+import type { Cockpit, CockpitSpawnError } from '../../types/cockpit';
+import { Provider, ProviderContext, ProviderError, SensorSample, SENSOR_KIND_TO_UNIT } from './types';
+
+const POWERCAP_ROOT = '/sys/class/powercap';
+const MICRO_UNITS_PER_WATT = 1_000_000;
+const DEFAULT_REFRESH_MS = 3000;
+const MIN_REFRESH_MS = 500;
+
+interface RaplDomainState {
+    id: string;
+    path: string;
+    label: string;
+    powerPath?: string;
+    energyPath?: string;
+    maxEnergy?: number;
+    lastEnergy?: number;
+    lastTimestamp?: number;
+    cachedPower?: number;
+}
+
+const isPermissionDenied = (error: unknown): boolean => {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+
+    const spawnError = error as CockpitSpawnError & { message?: string };
+    if (spawnError.problem === 'access-denied') {
+        return true;
+    }
+
+    if (typeof spawnError.message === 'string' && /permission denied/i.test(spawnError.message)) {
+        return true;
+    }
+
+    return false;
+};
+
+const parseNumber = (value: string | null | undefined): number | undefined => {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+        return undefined;
+    }
+
+    const parsed = Number.parseFloat(trimmed);
+    return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+const spawnText = async (cockpitInstance: Cockpit, command: string[] | string): Promise<string> => {
+    try {
+        return await cockpitInstance.spawn(command, { superuser: 'try', err: 'out' });
+    } catch (error) {
+        if (isPermissionDenied(error)) {
+            throw new ProviderError('Permission denied while reading powercap data', 'permission-denied', {
+                cause: error instanceof Error ? error : undefined,
+            });
+        }
+
+        throw new ProviderError('Failed to read powercap data from the system', 'unexpected', {
+            cause: error instanceof Error ? error : undefined,
+        });
+    }
+};
+
+const readFile = async (cockpitInstance: Cockpit, path: string): Promise<string | null> => {
+    try {
+        const handle = cockpitInstance.file(path);
+        const content = await handle.read();
+        handle.close();
+        return content;
+    } catch (error) {
+        if (isPermissionDenied(error)) {
+            throw new ProviderError('Permission denied while reading powercap data', 'permission-denied', {
+                cause: error instanceof Error ? error : undefined,
+            });
+        }
+
+        return null;
+    }
+};
+
+const readNumberFile = async (cockpitInstance: Cockpit, path: string | undefined): Promise<number | undefined> => {
+    if (!path) {
+        return undefined;
+    }
+
+    const content = await readFile(cockpitInstance, path);
+    const parsed = parseNumber(content ?? undefined);
+    return typeof parsed === 'number' ? parsed : undefined;
+};
+
+const buildSample = (domain: RaplDomainState, watts: number): SensorSample => ({
+    kind: 'power',
+    id: `${domain.id}:power`,
+    label: domain.label,
+    value: watts,
+    unit: SENSOR_KIND_TO_UNIT.power,
+    chipId: domain.id,
+    chipLabel: domain.label,
+    chipName: domain.label,
+    category: 'power',
+});
+
+const readWatts = async (cockpitInstance: Cockpit, domain: RaplDomainState, now: number): Promise<number | undefined> => {
+    if (domain.powerPath) {
+        const microwatts = await readNumberFile(cockpitInstance, domain.powerPath);
+        if (typeof microwatts === 'number') {
+            domain.cachedPower = microwatts / MICRO_UNITS_PER_WATT;
+            return domain.cachedPower;
+        }
+
+        if (typeof domain.cachedPower === 'number') {
+            return domain.cachedPower;
+        }
+    }
+
+    if (!domain.energyPath) {
+        return undefined;
+    }
+
+    const energy = await readNumberFile(cockpitInstance, domain.energyPath);
+    if (typeof energy !== 'number') {
+        domain.lastEnergy = undefined;
+        domain.lastTimestamp = undefined;
+        return undefined;
+    }
+
+    if (typeof domain.lastEnergy !== 'number' || typeof domain.lastTimestamp !== 'number') {
+        domain.lastEnergy = energy;
+        domain.lastTimestamp = now;
+        return undefined;
+    }
+
+    const elapsedMs = now - domain.lastTimestamp;
+    if (elapsedMs <= 0) {
+        domain.lastEnergy = energy;
+        domain.lastTimestamp = now;
+        return undefined;
+    }
+
+    let deltaEnergy = energy - domain.lastEnergy;
+    if (deltaEnergy < 0 && typeof domain.maxEnergy === 'number') {
+        deltaEnergy += domain.maxEnergy;
+    }
+
+    if (deltaEnergy < 0) {
+        domain.lastEnergy = energy;
+        domain.lastTimestamp = now;
+        return undefined;
+    }
+
+    domain.lastEnergy = energy;
+    domain.lastTimestamp = now;
+
+    return deltaEnergy / MICRO_UNITS_PER_WATT / (elapsedMs / 1000);
+};
+
+const listRaplDomains = async (cockpitInstance: Cockpit): Promise<RaplDomainState[]> => {
+    const now = Date.now();
+    const rawList = await spawnText(cockpitInstance, [
+        'sh',
+        '-c',
+        `find ${POWERCAP_ROOT} -maxdepth 3 -type d -name "intel-rapl:*" 2>/dev/null`,
+    ]).catch(error => {
+        if (error instanceof ProviderError && error.code === 'unexpected') {
+            return '';
+        }
+
+        throw error;
+    });
+
+    const paths = rawList
+            .split('\n')
+            .map(entry => entry.trim())
+            .filter(Boolean);
+
+    const domains: RaplDomainState[] = [];
+
+    for (const path of paths) {
+        const id = path.split('/').pop() ?? path;
+        const label = (await readFile(cockpitInstance, `${path}/name`))?.trim() || id;
+        const energy = await readNumberFile(cockpitInstance, `${path}/energy_uj`);
+        const powerValue = await readNumberFile(cockpitInstance, `${path}/power_uw`);
+        const maxEnergy = await readNumberFile(cockpitInstance, `${path}/max_energy_range_uj`);
+
+        if (typeof energy !== 'number' && typeof powerValue !== 'number') {
+            continue;
+        }
+
+        domains.push({
+            id,
+            path,
+            label,
+            energyPath: typeof energy === 'number' ? `${path}/energy_uj` : undefined,
+            powerPath: typeof powerValue === 'number' ? `${path}/power_uw` : undefined,
+            maxEnergy,
+            lastEnergy: typeof energy === 'number' ? energy : undefined,
+            lastTimestamp: typeof energy === 'number' ? now : undefined,
+            cachedPower: typeof powerValue === 'number' ? powerValue / MICRO_UNITS_PER_WATT : undefined,
+        });
+    }
+
+    return domains;
+};
+
+export class PowercapProvider implements Provider {
+    readonly name = 'powercap';
+    private intervalHandle: number | undefined;
+
+    async isAvailable(): Promise<boolean> {
+        const cockpitInstance = getCockpit();
+        const output = await spawnText(cockpitInstance, [
+            'sh',
+            '-c',
+            `find ${POWERCAP_ROOT} -maxdepth 1 -type d -name "intel-rapl:*" -print -quit 2>/dev/null`,
+        ]).catch(error => {
+            if (error instanceof ProviderError && error.code === 'unexpected') {
+                return '';
+            }
+
+            throw error;
+        });
+
+        return output.trim().length > 0;
+    }
+
+    start(onChange: (samples: SensorSample[]) => void, context?: ProviderContext) {
+        const cockpitInstance = getCockpit();
+        let disposed = false;
+        let domains: RaplDomainState[] = [];
+
+        const pollMs = Math.max(context?.refreshIntervalMs ?? DEFAULT_REFRESH_MS, MIN_REFRESH_MS);
+
+        const collect = async () => {
+            try {
+                const now = Date.now();
+                const samples: SensorSample[] = [];
+
+                for (const domain of domains) {
+                    const watts = await readWatts(cockpitInstance, domain, now);
+                    if (typeof watts === 'number') {
+                        samples.push(buildSample(domain, watts));
+                    }
+                }
+
+                onChange(samples);
+            } catch (error) {
+                const providerError =
+                    error instanceof ProviderError
+                        ? error
+                        : new ProviderError((error as Error).message || 'powercap failure', 'unexpected', {
+                            cause: error instanceof Error ? error : undefined,
+                        });
+                context?.onError?.(providerError);
+            }
+        };
+
+        const bootstrap = async () => {
+            try {
+                domains = await listRaplDomains(cockpitInstance);
+                if (disposed) {
+                    return;
+                }
+
+                if (domains.length === 0) {
+                    onChange([]);
+                    return;
+                }
+
+                await collect();
+                if (disposed) {
+                    return;
+                }
+
+                this.intervalHandle = window.setInterval(() => void collect(), pollMs);
+            } catch (error) {
+                const providerError =
+                    error instanceof ProviderError
+                        ? error
+                        : new ProviderError((error as Error).message || 'powercap failure', 'unexpected', {
+                            cause: error instanceof Error ? error : undefined,
+                        });
+                context?.onError?.(providerError);
+            }
+        };
+
+        void bootstrap();
+
+        return () => {
+            disposed = true;
+            if (this.intervalHandle) {
+                window.clearInterval(this.intervalHandle);
+            }
+        };
+    }
+}
+
+export const powercapProvider = new PowercapProvider();

--- a/src/lib/providers/types.ts
+++ b/src/lib/providers/types.ts
@@ -1,6 +1,6 @@
 import type { SensorCategory } from '../../types/sensors';
 
-export type SensorKind = 'temp' | 'fan' | 'volt' | 'other';
+export type SensorKind = 'temp' | 'fan' | 'volt' | 'power' | 'other';
 
 export interface SensorSample {
     kind: SensorKind;
@@ -46,6 +46,7 @@ export const SENSOR_KIND_TO_CATEGORY: Record<SensorKind, SensorCategory> = {
     temp: 'temperature',
     fan: 'fan',
     volt: 'voltage',
+    power: 'power',
     other: 'unknown',
 };
 
@@ -53,5 +54,6 @@ export const SENSOR_KIND_TO_UNIT: Record<SensorKind, string | undefined> = {
     temp: '°C',
     fan: 'RPM',
     volt: 'V',
+    power: 'W',
     other: undefined,
 };

--- a/src/utils/grouping.ts
+++ b/src/utils/grouping.ts
@@ -6,15 +6,13 @@ import type { SensorCategory, SensorChipGroup } from '../types/sensors';
  * Unknown sensor groups are only returned when the dedicated "Other sensors" tab is queried,
  * which prevents them from being duplicated across the individual category tabs.
  *
- * Power related sensors currently have no dedicated tab, so they are surfaced in the same
- * catch-all list to ensure they remain visible to the user.
  */
 export const groupsForCategory = (
     groups: SensorChipGroup[],
     category: SensorCategory,
 ): SensorChipGroup[] => {
     if (category === 'unknown') {
-        return groups.filter(group => group.category === 'unknown' || group.category === 'power');
+        return groups.filter(group => group.category === 'unknown');
     }
 
     return groups.filter(group => group.category === category);


### PR DESCRIPTION
## Summary
- add a Watts tab alongside existing sensor categories
- introduce a powercap provider that reads RAPL power data for display as watt readings
- update grouping logic and tests to treat power sensors as a first-class category

## Testing
- npm test -- groups-for-category useSensors.helpers

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691efff852108328b872de4d0220d69d)