### PR TITLE
Surface privilege warning when power sensors need privileges

### DIFF
--- a/src/hooks/useSensors.ts
+++ b/src/hooks/useSensors.ts
@@ -37,7 +37,6 @@ export interface UseSensorsResult extends UseSensorsState {
 
 const PRIMARY_PROVIDERS: Provider[] = [hwmonProvider, lmSensorsProvider];
 const AUXILIARY_PROVIDERS: Provider[] = [powercapProvider, nvmeProvider];
-const AUXILIARY_PROVIDER_NAMES = new Set(AUXILIARY_PROVIDERS.map(provider => provider.name));
 const AGGREGATION_ORDER = PRIMARY_PROVIDERS.concat(AUXILIARY_PROVIDERS).map(provider => provider.name);
 
 const aggregateSamples = (samplesByProvider: Map<string, SensorSample[]>): SampleWithProvider[] => {

--- a/src/hooks/useSensors.ts
+++ b/src/hooks/useSensors.ts
@@ -142,7 +142,7 @@ export const useSensors = (refreshIntervalMs = DEFAULT_SENSOR_REFRESH_MS): UseSe
 
             const aggregated = aggregateSamples(samplesByProvider);
             setState(prev => {
-                if (prev.status === 'needs-privileges' || prev.status === 'error') {
+                if (prev.status === 'error') {
                     return prev;
                 }
 


### PR DESCRIPTION
## Summary
- keep sensor status in a privilege-required state when a provider reports permission errors so users see the warning
- ensure sensor data remains visible while highlighting the need for elevated permissions
- adjust permission-handling test to simulate provider error callbacks

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926e1e5679c83289635ed316b743957)