### PR TITLE
Require privileged access for sensor providers

### DIFF
--- a/src/lib/providers/lm-sensors.ts
+++ b/src/lib/providers/lm-sensors.ts
@@ -110,7 +110,7 @@ const prettifyLabel = (label: string): string => {
 
 const readSensorsJson = async (cockpitInstance: Cockpit): Promise<unknown> => {
     try {
-        const output = await cockpitInstance.spawn(['sensors', '-jA'], { superuser: 'try', err: 'out' });
+        const output = await cockpitInstance.spawn(['sensors', '-jA'], { superuser: 'require', err: 'out' });
         const trimmed = output.trim();
         if (!trimmed) {
             return {};

--- a/src/lib/providers/nvme.ts
+++ b/src/lib/providers/nvme.ts
@@ -58,7 +58,7 @@ const isCommandMissing = (error: unknown): boolean => {
 
 const runJsonCommand = async (cockpitInstance: Cockpit, command: string[]): Promise<unknown> => {
     try {
-        const output = await cockpitInstance.spawn(command, { superuser: 'try', err: 'out' });
+        const output = await cockpitInstance.spawn(command, { superuser: 'require', err: 'out' });
         const trimmed = output.trim();
         if (!trimmed) {
             return {};

--- a/src/lib/providers/powercap.ts
+++ b/src/lib/providers/powercap.ts
@@ -52,7 +52,7 @@ const parseNumber = (value: string | null | undefined): number | undefined => {
 
 const spawnText = async (cockpitInstance: Cockpit, command: string[] | string): Promise<string> => {
     try {
-        return await cockpitInstance.spawn(command, { superuser: 'try', err: 'out' });
+        return await cockpitInstance.spawn(command, { superuser: 'require', err: 'out' });
     } catch (error) {
         if (isPermissionDenied(error)) {
             throw new ProviderError('Permission denied while reading powercap data', 'permission-denied', {
@@ -68,7 +68,7 @@ const spawnText = async (cockpitInstance: Cockpit, command: string[] | string): 
 
 const readFile = async (cockpitInstance: Cockpit, path: string): Promise<string | null> => {
     try {
-        const handle = cockpitInstance.file(path);
+        const handle = cockpitInstance.file(path, { superuser: 'require' });
         const content = await handle.read();
         handle.close();
         return content;


### PR DESCRIPTION
## Summary
- request privileged cockpit access when reading sensors so hardware data is available to admins
- surface permission denials from sysfs-backed providers to trigger privilege prompts

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69278ec610048328bc8ef72e2bed3c4d)