### PR TITLE
feat: broaden power sensor support

### DIFF
--- a/src/lib/providers/__tests__/lm-sensors.test.ts
+++ b/src/lib/providers/__tests__/lm-sensors.test.ts
@@ -64,4 +64,24 @@ describe('normalizeLmSensors', () => {
         expect(samples.find(sample => sample.kind === 'volt')?.value).toBeCloseTo(1.032);
         expect(samples.find(sample => sample.kind === 'temp')?.value).toBeCloseTo(44);
     });
+
+    it('classifies power inputs as power sensors', () => {
+        const payload = {
+            'nct6775-isa-0290': {
+                Adapter: 'ISA adapter',
+                power1: {
+                    power1_input: 4.5,
+                    power1_label: 'CPU Package',
+                },
+            },
+        };
+
+        const samples = normalizeLmSensors(payload);
+        const powerSample = samples.find(sample => sample.kind === 'power');
+
+        expect(powerSample?.label).toBe('CPU Package');
+        expect(powerSample?.value).toBeCloseTo(4.5);
+        expect(powerSample?.category).toBe('power');
+        expect(powerSample?.unit).toBe('W');
+    });
 });

--- a/src/lib/providers/lm-sensors.ts
+++ b/src/lib/providers/lm-sensors.ts
@@ -89,6 +89,8 @@ const sensorKindForKey = (key: string): SensorKind => {
         case 'vin':
         case 'vcc':
             return 'volt';
+        case 'power':
+            return 'power';
         default:
             return 'other';
     }

--- a/src/lib/providers/powercap.ts
+++ b/src/lib/providers/powercap.ts
@@ -6,6 +6,7 @@ const POWERCAP_ROOT = '/sys/class/powercap';
 const MICRO_UNITS_PER_WATT = 1_000_000;
 const DEFAULT_REFRESH_MS = 3000;
 const MIN_REFRESH_MS = 500;
+const RAPL_FIND_EXPRESSION = '\\( -name "*-rapl:*" -o -name "rapl:*" \\)';
 
 interface RaplDomainState {
     id: string;
@@ -164,7 +165,7 @@ const listRaplDomains = async (cockpitInstance: Cockpit): Promise<RaplDomainStat
     const rawList = await spawnText(cockpitInstance, [
         'sh',
         '-c',
-        `find ${POWERCAP_ROOT} -maxdepth 3 -type d -name "intel-rapl:*" 2>/dev/null`,
+        `find ${POWERCAP_ROOT} -maxdepth 3 -type d ${RAPL_FIND_EXPRESSION} 2>/dev/null`,
     ]).catch(error => {
         if (error instanceof ProviderError && error.code === 'unexpected') {
             return '';
@@ -216,7 +217,7 @@ export class PowercapProvider implements Provider {
         const output = await spawnText(cockpitInstance, [
             'sh',
             '-c',
-            `find ${POWERCAP_ROOT} -maxdepth 1 -type d -name "intel-rapl:*" -print -quit 2>/dev/null`,
+            `find ${POWERCAP_ROOT} -maxdepth 1 -type d ${RAPL_FIND_EXPRESSION} -print -quit 2>/dev/null`,
         ]).catch(error => {
             if (error instanceof ProviderError && error.code === 'unexpected') {
                 return '';


### PR DESCRIPTION
## Summary
- classify lm-sensors `power*_input` readings as power samples so wattage values from super I/O chips are exposed
- widen powercap discovery to consider generic RAPL domains instead of only `intel-rapl:*`
- add regression coverage for power sensor normalization

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69279d40719483288a90105129357e58)