### PR TITLE
fix: correct nvme smart-log command argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,10 @@ following order:
 1. `/sys/class/hwmon` for direct kernel sensor exposure.
 2. `sensors -j` from the lm-sensors package.
 3. `nvme smart-log <device> -o json` from nvme-cli for NVMe device temperatures.
+4. `smartctl -i -A -j <device>` from smartmontools for SATA/SAS drive temperatures.
 
 The first backend that reports data for a given sensor kind feeds the UI, while
-NVMe telemetry is always added as an extra source when available. If no backend
+NVMe and SATA drive telemetry is always added as an extra source when available. If no backend
 is present, the page renders a banner with setup instructions and offers a
 single-click copy of the recommended installation command:
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ following order:
 
 1. `/sys/class/hwmon` for direct kernel sensor exposure.
 2. `sensors -j` from the lm-sensors package.
-3. `nvme smart-log -o json` from nvme-cli for NVMe device temperatures.
+3. `nvme smart-log <device> -o json` from nvme-cli for NVMe device temperatures.
 
 The first backend that reports data for a given sensor kind feeds the UI, while
 NVMe telemetry is always added as an extra source when available. If no backend

--- a/src/hooks/useSensors.ts
+++ b/src/hooks/useSensors.ts
@@ -6,6 +6,7 @@ import { hwmonProvider } from '../lib/providers/hwmon';
 import { lmSensorsProvider } from '../lib/providers/lm-sensors';
 import { nvmeProvider } from '../lib/providers/nvme';
 import { powercapProvider } from '../lib/providers/powercap';
+import { smartctlProvider } from '../lib/providers/smartctl';
 import {
     Provider,
     ProviderError,
@@ -36,7 +37,7 @@ export interface UseSensorsResult extends UseSensorsState {
 }
 
 const PRIMARY_PROVIDERS: Provider[] = [hwmonProvider, lmSensorsProvider];
-const AUXILIARY_PROVIDERS: Provider[] = [powercapProvider, nvmeProvider];
+const AUXILIARY_PROVIDERS: Provider[] = [powercapProvider, nvmeProvider, smartctlProvider];
 const AGGREGATION_ORDER = PRIMARY_PROVIDERS.concat(AUXILIARY_PROVIDERS).map(provider => provider.name);
 
 const aggregateSamples = (samplesByProvider: Map<string, SensorSample[]>): SampleWithProvider[] => {

--- a/src/lib/providers/__tests__/nvme.test.ts
+++ b/src/lib/providers/__tests__/nvme.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { convertTemperature, buildSample, NvmeDeviceInfo } from '../nvme';
+
+describe('convertTemperature', () => {
+    it('returns undefined for non-number values', () => {
+        expect(convertTemperature(undefined)).toBeUndefined();
+        expect(convertTemperature(NaN)).toBeUndefined();
+        expect(convertTemperature(Infinity)).toBeUndefined();
+    });
+
+    it('converts Kelvin temperatures (> 200) to Celsius', () => {
+        // 300K = 27°C
+        expect(convertTemperature(300)).toBe(27);
+        // 273K = 0°C
+        expect(convertTemperature(273)).toBe(0);
+        // 373K = 100°C
+        expect(convertTemperature(373)).toBe(100);
+    });
+
+    it('returns Celsius values as-is when <= 200', () => {
+        expect(convertTemperature(45)).toBe(45);
+        expect(convertTemperature(70)).toBe(70);
+        expect(convertTemperature(200)).toBe(200);
+    });
+
+    it('handles edge case at boundary (201)', () => {
+        // 201K would be -72°C, which is below absolute zero being unrealistic
+        // but the function treats > 200 as Kelvin
+        expect(convertTemperature(201)).toBe(201 - 273);
+    });
+});
+
+describe('buildSample', () => {
+    it('builds sample with model and serial', () => {
+        const device: NvmeDeviceInfo = {
+            name: '/dev/nvme0',
+            model: 'Samsung 970 EVO Plus',
+            serial: 'S4EWNX0R123456',
+        };
+
+        const sample = buildSample(device, 42);
+
+        expect(sample.kind).toBe('temp');
+        expect(sample.id).toBe('/dev/nvme0:temperature');
+        expect(sample.label).toBe('Samsung 970 EVO Plus #S4EWNX0R123456');
+        expect(sample.value).toBe(42);
+        expect(sample.unit).toBe('°C');
+        expect(sample.chipId).toBe('/dev/nvme0');
+        expect(sample.chipLabel).toBe('Samsung 970 EVO Plus (/dev/nvme0)');
+        expect(sample.chipName).toBe('Samsung 970 EVO Plus');
+    });
+
+    it('builds sample without serial', () => {
+        const device: NvmeDeviceInfo = {
+            name: '/dev/nvme1',
+            model: 'WD Black SN850',
+        };
+
+        const sample = buildSample(device, 55);
+
+        expect(sample.label).toBe('WD Black SN850');
+        expect(sample.chipLabel).toBe('WD Black SN850 (/dev/nvme1)');
+    });
+
+    it('builds sample without model', () => {
+        const device: NvmeDeviceInfo = {
+            name: '/dev/nvme2',
+        };
+
+        const sample = buildSample(device, 38);
+
+        expect(sample.label).toBe('NVMe device');
+        expect(sample.chipLabel).toBe('/dev/nvme2');
+        expect(sample.chipName).toBe('/dev/nvme2');
+    });
+
+    it('builds sample without model but with serial', () => {
+        const device: NvmeDeviceInfo = {
+            name: '/dev/nvme3',
+            serial: 'ABC123',
+        };
+
+        const sample = buildSample(device, 40);
+
+        expect(sample.label).toBe('NVMe device #ABC123');
+    });
+});

--- a/src/lib/providers/__tests__/smartctl.test.ts
+++ b/src/lib/providers/__tests__/smartctl.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractTemperature, buildSample, SmartctlDeviceInfo } from '../smartctl';
+
+describe('extractTemperature', () => {
+    it('returns undefined for empty data', () => {
+        expect(extractTemperature({})).toBeUndefined();
+    });
+
+    it('extracts temperature from temperature.current field', () => {
+        const data = {
+            temperature: {
+                current: 36,
+            },
+        };
+
+        expect(extractTemperature(data)).toBe(36);
+    });
+
+    it('falls back to SMART attribute 194 when temperature.current is missing', () => {
+        const data = {
+            ata_smart_attributes: {
+                table: [
+                    {
+                        id: 194,
+                        name: 'Temperature_Celsius',
+                        value: 42,
+                        raw: { value: 42, string: '42' },
+                    },
+                ],
+            },
+        };
+
+        expect(extractTemperature(data)).toBe(42);
+    });
+
+    it('falls back to SMART attribute 190 when 194 is missing', () => {
+        const data = {
+            ata_smart_attributes: {
+                table: [
+                    {
+                        id: 190,
+                        name: 'Airflow_Temperature_Cel',
+                        value: 38,
+                        raw: { value: 38, string: '38' },
+                    },
+                ],
+            },
+        };
+
+        expect(extractTemperature(data)).toBe(38);
+    });
+
+    it('prefers temperature.current over SMART attributes', () => {
+        const data = {
+            temperature: {
+                current: 36,
+            },
+            ata_smart_attributes: {
+                table: [
+                    {
+                        id: 194,
+                        name: 'Temperature_Celsius',
+                        value: 99,
+                        raw: { value: 99, string: '99' },
+                    },
+                ],
+            },
+        };
+
+        expect(extractTemperature(data)).toBe(36);
+    });
+
+    it('prefers attribute 194 over 190', () => {
+        const data = {
+            ata_smart_attributes: {
+                table: [
+                    {
+                        id: 190,
+                        name: 'Airflow_Temperature_Cel',
+                        value: 30,
+                        raw: { value: 30, string: '30' },
+                    },
+                    {
+                        id: 194,
+                        name: 'Temperature_Celsius',
+                        value: 36,
+                        raw: { value: 36, string: '36' },
+                    },
+                ],
+            },
+        };
+
+        expect(extractTemperature(data)).toBe(36);
+    });
+
+    it('returns undefined for non-finite temperature values', () => {
+        const data = {
+            temperature: {
+                current: NaN,
+            },
+        };
+
+        expect(extractTemperature(data)).toBeUndefined();
+    });
+});
+
+describe('buildSample', () => {
+    it('builds sample with model and serial', () => {
+        const device: SmartctlDeviceInfo = {
+            name: '/dev/sda',
+            model: 'KINGSTON SA400S37240G',
+            serial: '50026B7282EA612A',
+        };
+
+        const sample = buildSample(device, 36);
+
+        expect(sample.kind).toBe('temp');
+        expect(sample.id).toBe('/dev/sda:temperature');
+        expect(sample.label).toBe('KINGSTON SA400S37240G #50026B7282EA612A');
+        expect(sample.value).toBe(36);
+        expect(sample.unit).toBe('°C');
+        expect(sample.chipId).toBe('/dev/sda');
+        expect(sample.chipLabel).toBe('KINGSTON SA400S37240G (/dev/sda)');
+        expect(sample.chipName).toBe('KINGSTON SA400S37240G');
+    });
+
+    it('builds sample without serial', () => {
+        const device: SmartctlDeviceInfo = {
+            name: '/dev/sdb',
+            model: 'Samsung SSD 860',
+        };
+
+        const sample = buildSample(device, 40);
+
+        expect(sample.label).toBe('Samsung SSD 860');
+        expect(sample.chipLabel).toBe('Samsung SSD 860 (/dev/sdb)');
+    });
+
+    it('builds sample without model', () => {
+        const device: SmartctlDeviceInfo = {
+            name: '/dev/sdc',
+        };
+
+        const sample = buildSample(device, 45);
+
+        expect(sample.label).toBe('SATA device');
+        expect(sample.chipLabel).toBe('/dev/sdc');
+        expect(sample.chipName).toBe('/dev/sdc');
+    });
+
+    it('builds sample without model but with serial', () => {
+        const device: SmartctlDeviceInfo = {
+            name: '/dev/sdd',
+            serial: 'ABC123',
+        };
+
+        const sample = buildSample(device, 38);
+
+        expect(sample.label).toBe('SATA device #ABC123');
+    });
+});

--- a/src/lib/providers/nvme.ts
+++ b/src/lib/providers/nvme.ts
@@ -6,7 +6,7 @@ import { isRecord, spawnJson, POLLING_INTERVALS } from './utils';
 const PROVIDER_NAME = 'nvme';
 const UNAVAILABLE_MESSAGE = 'nvme-cli is not available on this system';
 
-interface NvmeDeviceInfo {
+export interface NvmeDeviceInfo {
     name: string;
     model?: string;
     serial?: string;
@@ -57,7 +57,7 @@ const listNvmeDevices = async (cockpitInstance: Cockpit): Promise<NvmeDeviceInfo
 };
 
 const readSmartLog = async (cockpitInstance: Cockpit, devicePath: string): Promise<NvmeSmartLog> => {
-    const payload = await runJsonCommand(cockpitInstance, ['nvme', 'smart-log', '--output-format=json', devicePath]);
+    const payload = await runJsonCommand(cockpitInstance, ['nvme', 'smart-log', devicePath, '--output-format=json']);
     if (!isRecord(payload)) {
         return {};
     }
@@ -65,7 +65,7 @@ const readSmartLog = async (cockpitInstance: Cockpit, devicePath: string): Promi
     return payload as NvmeSmartLog;
 };
 
-const convertTemperature = (raw?: number): number | undefined => {
+export const convertTemperature = (raw?: number): number | undefined => {
     if (typeof raw !== 'number' || !Number.isFinite(raw)) {
         return undefined;
     }
@@ -78,7 +78,7 @@ const convertTemperature = (raw?: number): number | undefined => {
     return raw;
 };
 
-const buildSample = (device: NvmeDeviceInfo, temperature: number): SensorSample => {
+export const buildSample = (device: NvmeDeviceInfo, temperature: number): SensorSample => {
     const labelParts = [device.model ?? 'NVMe device'];
     if (device.serial) {
         labelParts.push(`#${device.serial}`);

--- a/src/lib/providers/smartctl.ts
+++ b/src/lib/providers/smartctl.ts
@@ -1,0 +1,238 @@
+import { getCockpit } from '../../utils/cockpit';
+import type { Cockpit } from '../../types/cockpit';
+import { Provider, ProviderContext, ProviderError, SensorSample, SENSOR_KIND_TO_UNIT } from './types';
+import { isRecord, spawnJson, POLLING_INTERVALS } from './utils';
+
+const PROVIDER_NAME = 'smartctl';
+const UNAVAILABLE_MESSAGE = 'smartmontools is not available on this system';
+
+export interface SmartctlDeviceInfo {
+    name: string;
+    model?: string;
+    serial?: string;
+    protocol?: string;
+}
+
+interface SmartctlScanResult {
+    devices?: Array<{
+        name?: string;
+        info_name?: string;
+        type?: string;
+        protocol?: string;
+    }>;
+}
+
+interface SmartctlDeviceData {
+    device?: {
+        name?: string;
+        info_name?: string;
+        type?: string;
+        protocol?: string;
+    };
+    model_name?: string;
+    serial_number?: string;
+    temperature?: {
+        current?: number;
+    };
+    ata_smart_attributes?: {
+        table?: Array<{
+            id: number;
+            name: string;
+            value: number;
+            raw?: {
+                value: number;
+                string: string;
+            };
+        }>;
+    };
+}
+
+/** Wrapper for spawnJson with smartctl provider configuration */
+const runJsonCommand = (cockpitInstance: Cockpit, command: string[]): Promise<unknown> =>
+    spawnJson(cockpitInstance, command, PROVIDER_NAME, UNAVAILABLE_MESSAGE);
+
+const listSmartctlDevices = async (cockpitInstance: Cockpit): Promise<SmartctlDeviceInfo[]> => {
+    const payload = await runJsonCommand(cockpitInstance, ['smartctl', '--scan', '-j']);
+    if (!isRecord(payload)) {
+        return [];
+    }
+
+    const result = payload as SmartctlScanResult;
+    if (!Array.isArray(result.devices)) {
+        return [];
+    }
+
+    const devices: SmartctlDeviceInfo[] = [];
+    for (const entry of result.devices) {
+        if (!isRecord(entry) || typeof entry.name !== 'string') {
+            continue;
+        }
+
+        devices.push({
+            name: entry.name,
+            protocol: typeof entry.protocol === 'string' ? entry.protocol : undefined,
+        });
+    }
+
+    return devices;
+};
+
+const readDeviceData = async (cockpitInstance: Cockpit, devicePath: string): Promise<SmartctlDeviceData> => {
+    // Use -i for device info and -A for attributes, combined in one call
+    const payload = await runJsonCommand(cockpitInstance, ['smartctl', '-i', '-A', '-j', devicePath]);
+    if (!isRecord(payload)) {
+        return {};
+    }
+
+    return payload as SmartctlDeviceData;
+};
+
+/**
+ * Extract temperature from smartctl data.
+ * Priority: temperature.current > ata_smart_attributes id 194 > id 190
+ */
+export const extractTemperature = (data: SmartctlDeviceData): number | undefined => {
+    // First try the direct temperature field
+    if (data.temperature?.current !== undefined && Number.isFinite(data.temperature.current)) {
+        return data.temperature.current;
+    }
+
+    // Fall back to SMART attributes
+    const table = data.ata_smart_attributes?.table;
+    if (!Array.isArray(table)) {
+        return undefined;
+    }
+
+    // Try attribute 194 (Temperature_Celsius) first, then 190 (Airflow_Temperature_Cel)
+    for (const attrId of [194, 190]) {
+        const attr = table.find(a => a.id === attrId);
+        if (attr?.value !== undefined && Number.isFinite(attr.value)) {
+            return attr.value;
+        }
+    }
+
+    return undefined;
+};
+
+export const buildSample = (device: SmartctlDeviceInfo, temperature: number): SensorSample => {
+    const labelParts = [device.model ?? 'SATA device'];
+    if (device.serial) {
+        labelParts.push(`#${device.serial}`);
+    }
+
+    const label = labelParts.join(' ');
+
+    return {
+        kind: 'temp',
+        id: `${device.name}:temperature`,
+        label,
+        value: temperature,
+        unit: SENSOR_KIND_TO_UNIT.temp,
+        chipId: device.name,
+        chipLabel: device.model ? `${device.model} (${device.name})` : device.name,
+        chipName: device.model ?? device.name,
+    };
+};
+
+export class SmartctlProvider implements Provider {
+    readonly name = 'smartctl';
+    private intervalHandle: number | undefined;
+
+    async isAvailable(): Promise<boolean> {
+        const cockpitInstance = getCockpit();
+        const devices = await listSmartctlDevices(cockpitInstance).catch(error => {
+            if (error instanceof ProviderError) {
+                if (error.code === 'permission-denied') {
+                    throw error;
+                }
+
+                if (error.code === 'unavailable') {
+                    return [];
+                }
+            }
+
+            return [];
+        });
+
+        return devices.length > 0;
+    }
+
+    start(onChange: (samples: SensorSample[]) => void, context?: ProviderContext) {
+        const cockpitInstance = getCockpit();
+        let disposed = false;
+
+        const poll = async () => {
+            try {
+                const devices = await listSmartctlDevices(cockpitInstance);
+                if (disposed) {
+                    return;
+                }
+
+                if (devices.length === 0) {
+                    onChange([]);
+                    return;
+                }
+
+                const samples: SensorSample[] = [];
+                for (const device of devices) {
+                    try {
+                        const data = await readDeviceData(cockpitInstance, device.name);
+
+                        // Enrich device info with model and serial from response
+                        if (data.model_name) {
+                            device.model = data.model_name.trim();
+                        }
+                        if (data.serial_number) {
+                            device.serial = data.serial_number.trim();
+                        }
+
+                        const temperature = extractTemperature(data);
+                        if (typeof temperature === 'number') {
+                            samples.push(buildSample(device, temperature));
+                        }
+                    } catch (error) {
+                        if (error instanceof ProviderError) {
+                            if (error.code === 'permission-denied') {
+                                context?.onError?.(error);
+                                return;
+                            }
+
+                            if (error.code === 'unavailable') {
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                onChange(samples);
+            } catch (error) {
+                if (disposed) {
+                    return;
+                }
+
+                if (error instanceof ProviderError) {
+                    context?.onError?.(error);
+                }
+            }
+        };
+
+        void poll();
+
+        if (typeof window !== 'undefined') {
+            const interval = context?.refreshIntervalMs ?? POLLING_INTERVALS.NVME;
+            this.intervalHandle = window.setInterval(() => {
+                void poll();
+            }, interval);
+        }
+
+        return () => {
+            disposed = true;
+            if (typeof window !== 'undefined' && this.intervalHandle) {
+                window.clearInterval(this.intervalHandle);
+                this.intervalHandle = undefined;
+            }
+        };
+    }
+}
+
+export const smartctlProvider = new SmartctlProvider();


### PR DESCRIPTION
The nvme-cli requires the device path to come before options.
Changed from: nvme smart-log --output-format=json <device>
To: nvme smart-log <device> --output-format=json

Also added unit tests for the nvme provider covering temperature conversion (Kelvin to Celsius) and sample building functions.