### PR TITLE
fix: center page content and hide temperature unit on non-temp tabs

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -32,6 +32,16 @@ body {
 
 .sensor-page {
     --pf-v6-c-page--section--m-width-limited--MaxWidth: none;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.pf-v6-c-tabs,
+.sensor-banner,
+.sensor-description {
+    width: 100%;
+    max-width: 1400px;
 }
 
 // Ensure the sensors table uses the available width while remaining scrollable when needed.

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -359,22 +359,24 @@ export const SensorTable: React.FC<SensorTableProps> = ({
                             </FormSelect>
                         </ToolbarItem>
                     </ToolbarGroup>
-                    <ToolbarGroup>
-                        <ToolbarItem>
-                            <label className="sensor-toolbar__label" htmlFor="sensor-unit-select">
-                                {_('Temperature unit')}
-                            </label>
-                            <FormSelect
-                                value={unit}
-                                onChange={value => handleUnitToggle(value as TemperatureUnit)}
-                                aria-label={_('Temperature unit selector')}
-                                id="sensor-unit-select"
-                            >
-                                <FormSelectOption value="C" label={_('Degrees Celsius (°C)')} />
-                                <FormSelectOption value="F" label={_('Degrees Fahrenheit (°F)')} />
-                            </FormSelect>
-                        </ToolbarItem>
-                    </ToolbarGroup>
+                    {category === 'temperature' && (
+                        <ToolbarGroup>
+                            <ToolbarItem>
+                                <label className="sensor-toolbar__label" htmlFor="sensor-unit-select">
+                                    {_('Temperature unit')}
+                                </label>
+                                <FormSelect
+                                    value={unit}
+                                    onChange={value => handleUnitToggle(value as TemperatureUnit)}
+                                    aria-label={_('Temperature unit selector')}
+                                    id="sensor-unit-select"
+                                >
+                                    <FormSelectOption value="C" label={_('Degrees Celsius (°C)')} />
+                                    <FormSelectOption value="F" label={_('Degrees Fahrenheit (°F)')} />
+                                </FormSelect>
+                            </ToolbarItem>
+                        </ToolbarGroup>
+                    )}
                     <ToolbarItem alignment={{ default: 'alignRight' }}>
                         <Tooltip content={_('Download session history as CSV')}>
                             <Button


### PR DESCRIPTION
- Add flexbox centering to .sensor-page and constrain content width to 1400px for .pf-v6-c-tabs, .sensor-banner, .sensor-description
- Conditionally render temperature unit selector only when the active category is 'temperature'

https://claude.ai/code/session_01FvW5aXYPeUCaBLyGabH9MM