### PR TITLE
fix: define table column widths with colgroup and fixed layout

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -56,6 +56,7 @@ body {
 
 .pf-c-table {
     width: 100%;
+    table-layout: fixed;
 }
 
 /* Section clara/oscura según PF (no forzar colores fijos) */
@@ -73,6 +74,16 @@ body {
 
 .pf-c-table td,
 .pf-c-table th {
+    word-break: break-word;
+}
+
+.pf-c-table td {
+    white-space: nowrap;
+}
+
+.pf-c-table td[data-label="Chip"],
+.pf-c-table td[data-label="Sensor"] {
+    white-space: normal;
     word-break: break-word;
 }
 

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -410,6 +410,15 @@ export const SensorTable: React.FC<SensorTableProps> = ({
             ) : (
                 <div className="pf-c-table-wrapper" role="presentation">
                     <table className="pf-c-table pf-m-compact pf-m-grid-md" role="grid" aria-label={_('Sensor readings')}>
+                        <colgroup>
+                            <col style={{ width: '2.5rem' }} />
+                            <col style={{ width: '22%' }} />
+                            <col style={{ width: '16%' }} />
+                            <col style={{ width: '10%' }} />
+                            <col style={{ width: '22%' }} />
+                            <col style={{ width: '14%' }} />
+                            <col style={{ width: '10%' }} />
+                        </colgroup>
                         <thead>
                             <tr>
                                 <th scope="col" aria-label={_('Pinned status')} />


### PR DESCRIPTION
Add a <colgroup> to SensorTable with explicit widths for each column (Pin, Chip, Sensor, Input, Min/Avg/Max, Trend, Source) so the table renders with stable, predictable proportions.

In app.scss, switch .pf-c-table to table-layout: fixed so colgroup widths take effect, add white-space: nowrap to numeric cells, and restore wrapping for Chip/Sensor columns via data-label selectors.

https://claude.ai/code/session_016rwMWJNPxeBB9rvtpyz2JN