### PR TITLE
fix: unbreak the release workflow and version detection

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ container:
   # official cockpit CI container, with cockpit related build and test dependencies
   # if you want to use your own, see the documentation about required packages:
   # https://github.com/cockpit-project/cockpit/blob/main/HACKING.md#getting-the-development-dependencies
-  image: quay.io/cockpit/tasks
+  image: ghcr.io/cockpit-project/tasks
   kvm: true
   # increase this if you have many tests that benefit from parallelism
   cpu: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
   source:
     runs-on: ubuntu-latest
     container:
-      image: quay.io/cockpit/tasks:latest
+      image: ghcr.io/cockpit-project/tasks:latest
       options: --user root
     permissions:
       # create GitHub release

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # extract name from package.json
 PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' package.json)
 RPM_NAME := cockpit-$(PACKAGE_NAME)
-VERSION := $(shell T=$$(git describe 2>/dev/null) || T=1; echo $$T | tr '-' '.')
+VERSION := $(shell T=$$(git describe --tags 2>/dev/null) || T=1; echo $$T | tr '-' '.')
 ifeq ($(TEST_OS),)
 TEST_OS = fedora-43
 endif


### PR DESCRIPTION
The release job failed to start because quay.io/cockpit/tasks is no longer publicly pullable; the Cockpit project publishes its tasks container on ghcr.io now. Update the Cirrus config to match.

git describe without --tags only sees annotated tags, so a plain "git tag X" produced version "1" in every artifact. Use --tags so both tag styles version the build correctly.