### PR TITLE
fix: install dpkg in the release job before building the deb

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Build release
         run: make dist
 
+      # the tasks container is Fedora-based and does not ship dpkg-deb
+      - name: Install dpkg for the Debian package build
+        run: dnf install -y dpkg
+
       - name: Build Deb release
         run: make deb
 


### PR DESCRIPTION
The ghcr.io/cockpit-project/tasks container is Fedora-based and does not ship dpkg-deb, so make deb died with error 127 right after the tarball built successfully.