### PR TITLE
feat: complete translations, provider tests and final PatternFly polish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,10 @@ po/$(PACKAGE_NAME).js.pot:
                 --from-code=UTF-8 $$(find src/ -type f \( -name '*.js' -o -name '*.jsx' -o -name '*.ts' -o -name '*.tsx' \))
 
 po/$(PACKAGE_NAME).html.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/html2po.js -o $@ $$(find src -name '*.html')
+	pkg/lib/html2po -o $@ $$(find src -name '*.html')
 
 po/$(PACKAGE_NAME).manifest.pot: $(NODE_MODULES_TEST) $(COCKPIT_REPO_STAMP)
-	pkg/lib/manifest2po.js src/manifest.json -o $@
+	pkg/lib/manifest2po src/manifest.json -o $@
 
 po/$(PACKAGE_NAME).metainfo.pot: $(APPSTREAMFILE)
 	xgettext --default-domain=$(PACKAGE_NAME) --output=$@ $<

--- a/po/de.po
+++ b/po/de.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sensors 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-09 16:09+0100\n"
+"POT-Creation-Date: 2026-07-09 20:56-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,211 +14,427 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1\n"
 
-#: src/index.html:20
-msgid "Cockpit Sensors"
-msgstr "Cockpit Sensoren"
+#: src/app/Application.tsx:393
+msgid "$0 readings"
+msgstr "$0 Messwerte"
 
-#: src/manifest.json:8 
-#: org.cockpit-project.sensors.metainfo.xml:5 
-#: src/app.jsx:162
+#: src/components/SensorTable.tsx:100
+msgid "10s"
+msgstr "10s"
+
+#: src/components/SensorTable.tsx:98
+msgid "2s"
+msgstr "2s"
+
+#: src/components/SensorTable.tsx:99
+msgid "5s"
+msgstr "5s"
+
+#: src/components/SensorTable.tsx:187
+msgid "Active fans"
+msgstr "Aktive Lüfter"
+
+#: src/components/SensorTable.tsx:197
+msgid "Active power sensors"
+msgstr "Aktive Leistungssensoren"
+
+#: src/components/SensorTable.tsx:202
+msgid "Active sensors"
+msgstr "Aktive Sensoren"
+
+#: src/components/SensorTable.tsx:182
+msgid "Active temperature sensors"
+msgstr "Aktive Temperatursensoren"
+
+#: src/components/SensorTable.tsx:192
+msgid "Active voltage rails"
+msgstr "Aktive Spannungsschienen"
+
+#: src/app/Application.tsx:364
+msgid "All sensors healthy"
+msgstr "Alle Sensoren in Ordnung"
+
+#: src/app/Application.tsx:343
+msgid ""
+"An unexpected error prevented the Sensors page from retrieving live metrics."
+msgstr ""
+"Ein unerwarteter Fehler verhinderte, dass die Sensorseite Live-Metriken "
+"abrief."
+
+#: src/app/Application.tsx:363
+msgid "Approaching threshold"
+msgstr "Nähert sich dem Schwellenwert"
+
+#: src/components/SensorTable.tsx:189
+msgid "Average fan speed"
+msgstr "Durchschnittliche Lüftergeschwindigkeit"
+
+#: src/components/SensorTable.tsx:199
+msgid "Average power draw"
+msgstr "Durchschnittliche Leistungsaufnahme"
+
+#: src/components/SensorTable.tsx:184
+msgid "Average temperature"
+msgstr "Durchschnittstemperatur"
+
+#: src/components/SensorTable.tsx:204
+msgid "Average value"
+msgstr "Durchschnittswert"
+
+#: src/components/SensorTable.tsx:194
+msgid "Average voltage"
+msgstr "Durchschnittsspannung"
+
+#: src/components/CsvModalViewer.tsx:62
+msgid "CSV content"
+msgstr "CSV-Inhalt"
+
+#: src/components/SensorTable.tsx:251
+msgid "Chip"
+msgstr "Chip"
+
+#: src/components/CsvModalViewer.tsx:80
+msgid "Close"
+msgstr "Schließen"
+
+#: src/app/Application.tsx:297
+msgid ""
+"Cockpit could not read sensor data without elevated permissions. Retry the "
+"operation to trigger a privilege prompt."
+msgstr ""
+"Cockpit konnte ohne erhöhte Berechtigungen keine Sensordaten lesen. "
+"Versuchen Sie den Vorgang erneut, um eine Berechtigungsabfrage auszulösen."
+
+#: src/components/SensorTable.tsx:77
+msgid "Cockpit did not receive any temperature readings for this system."
+msgstr "Cockpit hat für dieses System keine Temperaturmesswerte erhalten."
+
+#: src/app/Application.tsx:60
+msgid "Compare temperature sensors reported by the host system."
+msgstr "Vergleichen Sie die vom System gemeldeten Temperatursensoren."
+
+#: src/app/Application.tsx:318 src/app/Application.tsx:322
+msgid "Copied"
+msgstr "Kopiert"
+
+#: src/components/CsvModalViewer.tsx:69
+msgid "Copy"
+msgstr "Kopieren"
+
+#: src/app/Application.tsx:318 src/app/Application.tsx:322
+msgid "Copy command"
+msgstr "Befehl kopieren"
+
+#: src/components/CsvModalViewer.tsx:67
+msgid "Copy to clipboard"
+msgstr "In die Zwischenablage kopieren"
+
+#: src/components/SensorTable.tsx:264
+msgid "Current"
+msgstr "Aktuell"
+
+#: src/app/Application.tsx:420
+msgid "Data sources"
+msgstr "Datenquellen"
+
+#: src/components/CsvModalViewer.tsx:75
+msgid "Download"
+msgstr "Herunterladen"
+
+#: src/app/Application.tsx:358
+msgid "Error"
+msgstr "Fehler"
+
+#: src/components/CsvModalViewer.tsx:50
+msgid "Export CSV"
+msgstr "CSV exportieren"
+
+#: src/app/Application.tsx:65
+msgid "Fans"
+msgstr "Lüfter"
+
+#: src/components/SensorTable.tsx:188
+msgid "Fastest fan"
+msgstr "Schnellster Lüfter"
+
+#: src/components/SensorTable.tsx:203
+msgid "Highest value"
+msgstr "Höchster Wert"
+
+#: src/components/SensorTable.tsx:193
+msgid "Highest voltage"
+msgstr "Höchste Spannung"
+
+#: src/components/SensorTable.tsx:183
+msgid "Hottest reading"
+msgstr "Heißester Messwert"
+
+#: src/app/Application.tsx:394
+msgid "Idle"
+msgstr "Inaktiv"
+
+#: src/app/Application.tsx:315
+msgid ""
+"Install the recommended packages below and rerun the detection to expose "
+"hardware monitoring sensors."
+msgstr ""
+"Installieren Sie die unten empfohlenen Pakete und führen Sie die Erkennung "
+"erneut aus, um Hardware-Überwachungssensoren bereitzustellen."
+
+#: src/app/Application.tsx:398
+msgid "Live hardware telemetry: temperature, fans, voltages and power."
+msgstr "Live-Hardware-Telemetrie: Temperatur, Lüfter, Spannungen und Leistung."
+
+#: src/app/Application.tsx:495 src/app/Application.tsx:498
+msgid "Loading sensor data..."
+msgstr "Sensordaten werden geladen ..."
+
+#: src/app/Application.tsx:66
+msgid "Monitor cooling without reloading the page."
+msgstr "Überwachen Sie die Kühlung, ohne die Seite neu zu laden."
+
+#: src/app/Application.tsx:357
+msgid "Needs privileges"
+msgstr "Berechtigungen erforderlich"
+
+#: src/app/Application.tsx:359
+msgid "No backends"
+msgstr "Keine Backends"
+
+#: src/app/Application.tsx:360
+msgid "No data"
+msgstr "Keine Daten"
+
+#: src/components/SensorTable.tsx:80
+msgid "No fan telemetry available"
+msgstr "Keine Lüfter-Telemetrie verfügbar"
+
+#: src/app/Application.tsx:332
+msgid "No live sensor readings were reported"
+msgstr "Es wurden keine aktuellen Sensorwerte gemeldet"
+
+#: src/components/SensorTable.tsx:92
+msgid "No miscellaneous sensors captured"
+msgstr "Keine sonstigen Sensoren erfasst"
+
+#: src/components/SensorTable.tsx:88
+msgid "No power sensors found"
+msgstr "Keine Leistungssensoren gefunden"
+
+#: src/app/Application.tsx:307
+msgid "No sensor backends are available on this system"
+msgstr "Auf diesem System sind keine Sensor-Backends verfügbar"
+
+#: src/components/SensorTable.tsx:76
+msgid "No temperature sensors detected"
+msgstr "Keine Temperatursensoren erkannt"
+
+#: src/components/SensorTable.tsx:85
+msgid "No voltage inputs were reported by the available sensor backends."
+msgstr "Die verfügbaren Sensor-Backends haben keine Spannungseingänge gemeldet."
+
+#: src/components/SensorTable.tsx:84
+msgid "No voltage sensors reported"
+msgstr "Keine Spannungssensoren gemeldet"
+
+#: src/app/Application.tsx:108
+msgid "Not updated yet"
+msgstr "Noch nicht aktualisiert"
+
+#: src/app/Application.tsx:321
+msgid "On Debian or Ubuntu:"
+msgstr "Unter Debian oder Ubuntu:"
+
+#: src/app/Application.tsx:317
+msgid "On Fedora, RHEL or CentOS:"
+msgstr "Unter Fedora, RHEL oder CentOS:"
+
+#: src/app/Application.tsx:83
+msgid "Other"
+msgstr "Sonstige"
+
+#: src/app/Application.tsx:435
+msgid "Pause / resume"
+msgstr "Pausieren / fortsetzen"
+
+#: src/app/Application.tsx:361
+msgid "Paused"
+msgstr "Pausiert"
+
+#: src/components/SensorTable.tsx:198
+msgid "Peak power draw"
+msgstr "Maximale Leistungsaufnahme"
+
+#: src/components/SensorTable.tsx:235 src/components/SensorTable.tsx:241
+msgid "Pin sensor"
+msgstr "Sensor anheften"
+
+#: src/components/SensorTable.tsx:233
+msgid "Pinned status"
+msgstr "Anheftstatus"
+
+#: src/app/Application.tsx:77
+msgid "Power"
+msgstr "Leistung"
+
+#: src/components/SensorTable.tsx:89
+msgid "Power metrics were not exposed for this host or backend."
+msgstr "Für diesen Host oder dieses Backend wurden keine Leistungsmetriken bereitgestellt."
+
+#: src/app/Application.tsx:292
+msgid "Retry with privileges"
+msgstr "Mit Berechtigungen erneut versuchen"
+
+#: src/app/Application.tsx:310
+msgid "Run detection again"
+msgstr "Erkennung erneut ausführen"
+
+#: src/app/Application.tsx:434
+msgid "Search"
+msgstr "Suchen"
+
+#: src/components/SensorTable.tsx:261
+msgid "Sensor"
+msgstr "Sensor"
+
+#: src/app/Application.tsx:461
+msgid "Sensor category list"
+msgstr "Liste der Sensorkategorien"
+
+#: src/app/Application.tsx:289
+msgid "Sensor data requires administrative privileges"
+msgstr "Sensordaten erfordern administrative Berechtigungen"
+
+#: src/components/SensorSummary.tsx:30
+msgid "Sensor highlights"
+msgstr "Sensor-Übersicht"
+
+#: src/index.html:20 src/app/Application.tsx:390 src/manifest.json:0
+#: org.cockpit-project.sensors.metainfo.xml:5
 msgid "Sensors"
 msgstr "Sensoren"
 
+#: org.cockpit-project.sensors.metainfo.xml:6
 #: org.cockpit-project.sensors.metainfo.xml:8
 msgid "Sensors cockpit module"
 msgstr "Sensoren Cockpit Modul"
 
-#: src/app.jsx:86
-msgid "lm-sensors not found, you want install it ?"
-msgstr "lm-sensors nicht gefunden, möchten Sie es installieren?"
+#: src/app/Application.tsx:379
+msgid "Sensors dashboard"
+msgstr "Sensoren-Dashboard"
 
-#: src/app.jsx:95
-msgid "this version of lm-sensors don't suport output sensors data!"
-msgstr "diese Version von lm-sensors unterstützt keine Ausgabe von Sensordaten!"
+#: src/components/SensorTable.tsx:93
+msgid "Sensors outside the dedicated categories are not reporting data."
+msgstr "Sensoren außerhalb der festen Kategorien melden keine Daten."
 
-#: src/app.jsx:130
-msgid "lm-sensors has a bug that converts all data to fahrenheit, including voltage, fans and etc."
-msgstr "lm-sensors hat einen Fehler, der alle Daten in Fahrenheit umwandelt, einschließlich Spannung, Lüfter usw."
+#: src/app/Application.tsx:84
+msgid ""
+"Sensors that do not match temperature, fan, voltage or power categories."
+msgstr "Sensoren, die nicht in die Kategorien Temperatur, Lüfter, Spannung oder Leistung passen."
 
-#: src/app.jsx:200
-msgid "Show temperature in Fahrenheit"
-msgstr "Temperatur in Fahrenheit anzeigen"
+#: src/app/Application.tsx:436
+msgid "Switch °C / °F"
+msgstr "°C / °F umschalten"
 
-#: src/app.jsx:206
-msgid "Expand all cards"
-msgstr "Erweitern Sie alle Karten"
+#: src/app/Application.tsx:78
+msgid "System and package power draw reported by RAPL interfaces."
+msgstr "Vom RAPL gemeldete Leistungsaufnahme von System und Package."
 
-#: src/app.jsx:174
-msgid "Install"
-msgstr "Installieren"
+#: src/app/Application.tsx:59
+msgid "Temperatures"
+msgstr "Temperaturen"
 
-#: src/app/Application.tsx
-msgid "Sensor data requires administrative privileges"
-msgstr "Sensordaten erfordern administrative Berechtigungen"
+#: src/components/SensorTable.tsx:81
+msgid "The hardware monitoring stack did not expose any fan speed sensors."
+msgstr "Der Hardware-Monitoring-Stack hat keine Lüftergeschwindigkeitssensoren bereitgestellt."
 
-#: src/app/Application.tsx
-msgid "Retry with privileges"
-msgstr "Mit Berechtigungen erneut versuchen"
+#: src/app/Application.tsx:335
+msgid ""
+"This environment may not expose physical sensors. Virtual machines commonly "
+"omit hardware monitoring interfaces."
+msgstr ""
+"Diese Umgebung stellt möglicherweise keine physischen Sensoren bereit. "
+"Virtuelle Maschinen lassen Hardware-Überwachungsschnittstellen häufig weg."
 
-#: src/app/Application.tsx
-msgid "Cockpit could not read sensor data without elevated permissions. Retry the operation to trigger a privilege prompt."
-msgstr "Cockpit konnte ohne erhöhte Berechtigungen keine Sensordaten lesen. Versuchen Sie den Vorgang erneut, um eine Berechtigungsabfrage auszulösen."
+#: src/app/Application.tsx:362
+msgid "Threshold exceeded"
+msgstr "Schwellenwert überschritten"
 
-#: src/app/Application.tsx
-msgid "No sensor backends are available on this system"
-msgstr "Auf diesem System sind keine Sensor-Backends verfügbar"
+#: src/app/Application.tsx:437
+msgid "Toggle table / cards"
+msgstr "Tabelle / Karten umschalten"
 
-#: src/app/Application.tsx
-msgid "Install the recommended packages below and rerun the detection to expose hardware monitoring sensors."
-msgstr "Installieren Sie die unten empfohlenen Pakete und führen Sie die Erkennung erneut aus, um Hardware-Überwachungssensoren bereitzustellen."
-
-#: src/app/Application.tsx
-msgid "Copy command"
-msgstr "Befehl kopieren"
-
-#: src/app/Application.tsx
-msgid "Copied"
-msgstr "Kopiert"
-
-#: src/app/Application.tsx
-msgid "Run detection again"
-msgstr "Erkennung erneut ausführen"
-
-#: src/app/Application.tsx
-msgid "No live sensor readings were reported"
-msgstr "Es wurden keine aktuellen Sensorwerte gemeldet"
-
-#: src/app/Application.tsx
-msgid "This environment may not expose physical sensors. Virtual machines commonly omit hardware monitoring interfaces."
-msgstr "Diese Umgebung stellt möglicherweise keine physischen Sensoren bereit. Virtuelle Maschinen lassen Hardware-Überwachungsschnittstellen häufig weg."
-
-#: src/app/Application.tsx
-msgid "Unable to collect sensor data"
-msgstr "Sensordaten konnten nicht gesammelt werden"
-
-#: src/app/Application.tsx
-msgid "An unexpected error prevented the Sensors page from retrieving live metrics."
-msgstr "Ein unerwarteter Fehler verhinderte, dass die Sensorseite Live-Metriken abrief."
-
-#: src/app/Application.tsx
+#: src/app/Application.tsx:347
 msgid "Try again"
 msgstr "Erneut versuchen"
 
-#: src/app/Application.tsx
-msgid "Data sources"
-msgstr "Datenquellen"
+#: src/components/CsvModalViewer.tsx:73
+msgid "Try download again"
+msgstr "Download erneut versuchen"
 
-#: src/app/Application.tsx
-msgid "(active)"
-msgstr "(aktiv)"
-#: src/components/SensorTable.tsx
-msgid "No temperature sensors detected"
-msgstr ""
+#: src/app/Application.tsx:341
+msgid "Unable to collect sensor data"
+msgstr "Sensordaten konnten nicht gesammelt werden"
 
-#: src/components/SensorTable.tsx
-msgid "Cockpit did not receive any temperature readings for this system."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No fan telemetry available"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "The hardware monitoring stack did not expose any fan speed sensors."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No voltage sensors reported"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No voltage inputs were reported by the available sensor backends."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No power sensors found"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Power metrics were not exposed for this host or backend."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No miscellaneous sensors captured"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Sensors outside the dedicated categories are not reporting data."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Sensor table controls"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Refresh interval"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Refresh interval selector"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Every 10 seconds"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Every 5 seconds"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Every 2 seconds"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Temperature unit"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Temperature unit selector"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Degrees Celsius (°C)"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Degrees Fahrenheit (°F)"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Download session history as CSV"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Export CSV"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Pinned status"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Pin sensor"
-msgstr ""
-
-#: src/components/SensorTable.tsx
+#: src/components/SensorTable.tsx:235 src/components/SensorTable.tsx:241
 msgid "Unpin sensor"
-msgstr ""
+msgstr "Sensor lösen"
 
-#: src/components/SensorTable.tsx
-msgid "Session min/avg/max"
-msgstr ""
+#: src/app/Application.tsx:115
+msgid "Updated $0h ago"
+msgstr "Aktualisiert vor $0h"
 
-#: src/components/SensorTable.tsx
-msgid "Trend"
-msgstr ""
+#: src/app/Application.tsx:114
+msgid "Updated $0m ago"
+msgstr "Aktualisiert vor $0m"
 
-#: src/components/SensorTable.tsx
-msgid "Source"
-msgstr ""
+#: src/app/Application.tsx:113
+msgid "Updated $0s ago"
+msgstr "Aktualisiert vor $0s"
+
+#: src/app/Application.tsx:112
+msgid "Updated just now"
+msgstr "Gerade aktualisiert"
+
+#: src/app/Application.tsx:72
+msgid "Voltage readings exposed by power supplies and on-board rails."
+msgstr "Spannungswerte von Netzteilen und Onboard-Schienen."
+
+#: src/app/Application.tsx:71
+msgid "Voltages"
+msgstr "Spannungen"
+
+#: src/app/Application.tsx:428
+msgid "active"
+msgstr "aktiv"
+
+#: src/components/SensorTable.tsx:454
+msgid "samples"
+msgstr "Messungen"
+
+#: src/components/SensorTable.tsx:615
+msgid "seconds"
+msgstr "Sekunden"
+
+#~ msgid "lm-sensors not found, you want install it ?"
+#~ msgstr "lm-sensors nicht gefunden, möchten Sie es installieren?"
+
+#~ msgid "this version of lm-sensors don't suport output sensors data!"
+#~ msgstr ""
+#~ "diese Version von lm-sensors unterstützt keine Ausgabe von Sensordaten!"
+
+#~ msgid ""
+#~ "lm-sensors has a bug that converts all data to fahrenheit, including "
+#~ "voltage, fans and etc."
+#~ msgstr ""
+#~ "lm-sensors hat einen Fehler, der alle Daten in Fahrenheit umwandelt, "
+#~ "einschließlich Spannung, Lüfter usw."
+
+#~ msgid "Show temperature in Fahrenheit"
+#~ msgstr "Temperatur in Fahrenheit anzeigen"
+
+#~ msgid "Expand all cards"
+#~ msgstr "Erweitern Sie alle Karten"
+
+#~ msgid "Install"
+#~ msgstr "Installieren"

--- a/po/es.po
+++ b/po/es.po
@@ -2,8 +2,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sensors 1.0\n"
-"Report-Msgid-Bugs-To: https://github.com/cockpit-project/cockpit-sensors/issues\n"
-"POT-Creation-Date: 2025-10-07 00:00+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-09 20:56-0500\n"
 "PO-Revision-Date: 2025-10-07 00:00+0000\n"
 "Last-Translator: \n"
 "Language-Team: Spanish\n"
@@ -13,282 +13,483 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/index.html:20
-msgid "Cockpit Sensors"
-msgstr "Sensores de Cockpit"
+#: src/app/Application.tsx:393
+msgid "$0 readings"
+msgstr "$0 lecturas"
 
-#: src/manifest.json:8
+#: src/components/SensorTable.tsx:100
+msgid "10s"
+msgstr "10s"
+
+#: src/components/SensorTable.tsx:98
+msgid "2s"
+msgstr "2s"
+
+#: src/components/SensorTable.tsx:99
+msgid "5s"
+msgstr "5s"
+
+#: src/components/SensorTable.tsx:187
+msgid "Active fans"
+msgstr "Ventiladores activos"
+
+#: src/components/SensorTable.tsx:197
+msgid "Active power sensors"
+msgstr "Sensores de energía activos"
+
+#: src/components/SensorTable.tsx:202
+msgid "Active sensors"
+msgstr "Sensores activos"
+
+#: src/components/SensorTable.tsx:182
+msgid "Active temperature sensors"
+msgstr "Sensores de temperatura activos"
+
+#: src/components/SensorTable.tsx:192
+msgid "Active voltage rails"
+msgstr "Líneas de voltaje activas"
+
+#: src/app/Application.tsx:364
+msgid "All sensors healthy"
+msgstr "Todos los sensores en buen estado"
+
+#: src/app/Application.tsx:343
+msgid ""
+"An unexpected error prevented the Sensors page from retrieving live metrics."
+msgstr ""
+"Un error inesperado impidió que la página de Sensores obtuviera métricas en "
+"vivo."
+
+#: src/app/Application.tsx:363
+msgid "Approaching threshold"
+msgstr "Acercándose al umbral"
+
+#: src/components/SensorTable.tsx:189
+msgid "Average fan speed"
+msgstr "Velocidad media de ventiladores"
+
+#: src/components/SensorTable.tsx:199
+msgid "Average power draw"
+msgstr "Consumo medio"
+
+#: src/components/SensorTable.tsx:184
+msgid "Average temperature"
+msgstr "Temperatura media"
+
+#: src/components/SensorTable.tsx:204
+msgid "Average value"
+msgstr "Valor medio"
+
+#: src/components/SensorTable.tsx:194
+msgid "Average voltage"
+msgstr "Voltaje medio"
+
+#: src/components/CsvModalViewer.tsx:62
+msgid "CSV content"
+msgstr "Contenido CSV"
+
+#: src/components/SensorTable.tsx:251
+msgid "Chip"
+msgstr "Chip"
+
+#: src/components/CsvModalViewer.tsx:80
+msgid "Close"
+msgstr "Cerrar"
+
+#: src/app/Application.tsx:297
+msgid ""
+"Cockpit could not read sensor data without elevated permissions. Retry the "
+"operation to trigger a privilege prompt."
+msgstr ""
+"Cockpit no pudo leer los datos de sensores sin permisos elevados. Reintenta "
+"la operación para mostrar la solicitud de privilegios."
+
+#: src/components/SensorTable.tsx:77
+msgid "Cockpit did not receive any temperature readings for this system."
+msgstr "Cockpit no recibió lecturas de temperatura para este sistema."
+
+#: src/app/Application.tsx:60
+msgid "Compare temperature sensors reported by the host system."
+msgstr "Compara los sensores de temperatura reportados por el sistema."
+
+#: src/app/Application.tsx:318 src/app/Application.tsx:322
+msgid "Copied"
+msgstr "Copiado"
+
+#: src/components/CsvModalViewer.tsx:69
+msgid "Copy"
+msgstr "Copiar"
+
+#: src/app/Application.tsx:318 src/app/Application.tsx:322
+msgid "Copy command"
+msgstr "Copiar comando"
+
+#: src/components/CsvModalViewer.tsx:67
+msgid "Copy to clipboard"
+msgstr "Copiar al portapapeles"
+
+#: src/components/SensorTable.tsx:264
+msgid "Current"
+msgstr "Actual"
+
+#: src/app/Application.tsx:420
+msgid "Data sources"
+msgstr "Fuentes de datos"
+
+#: src/components/CsvModalViewer.tsx:75
+msgid "Download"
+msgstr "Descargar"
+
+#: src/app/Application.tsx:358
+msgid "Error"
+msgstr "Error"
+
+#: src/components/CsvModalViewer.tsx:50
+msgid "Export CSV"
+msgstr "Exportar CSV"
+
+#: src/app/Application.tsx:65
+msgid "Fans"
+msgstr "Ventiladores"
+
+#: src/components/SensorTable.tsx:188
+msgid "Fastest fan"
+msgstr "Ventilador más rápido"
+
+#: src/components/SensorTable.tsx:203
+msgid "Highest value"
+msgstr "Valor más alto"
+
+#: src/components/SensorTable.tsx:193
+msgid "Highest voltage"
+msgstr "Voltaje más alto"
+
+#: src/components/SensorTable.tsx:183
+msgid "Hottest reading"
+msgstr "Lectura más caliente"
+
+#: src/app/Application.tsx:394
+msgid "Idle"
+msgstr "Inactivo"
+
+#: src/app/Application.tsx:315
+msgid ""
+"Install the recommended packages below and rerun the detection to expose "
+"hardware monitoring sensors."
+msgstr ""
+"Instala los paquetes recomendados a continuación y ejecuta nuevamente la "
+"detección para exponer los sensores de monitorización de hardware."
+
+#: src/app/Application.tsx:398
+msgid "Live hardware telemetry: temperature, fans, voltages and power."
+msgstr "Telemetría de hardware en vivo: temperatura, ventiladores, voltajes y energía."
+
+#: src/app/Application.tsx:495 src/app/Application.tsx:498
+msgid "Loading sensor data..."
+msgstr "Cargando datos de sensores..."
+
+#: src/app/Application.tsx:66
+msgid "Monitor cooling without reloading the page."
+msgstr "Supervisa la refrigeración sin recargar la página."
+
+#: src/app/Application.tsx:357
+msgid "Needs privileges"
+msgstr "Requiere privilegios"
+
+#: src/app/Application.tsx:359
+msgid "No backends"
+msgstr "Sin backends"
+
+#: src/app/Application.tsx:360
+msgid "No data"
+msgstr "Sin datos"
+
+#: src/components/SensorTable.tsx:80
+msgid "No fan telemetry available"
+msgstr "No hay telemetría de ventiladores disponible"
+
+#: src/app/Application.tsx:332
+msgid "No live sensor readings were reported"
+msgstr "No se informaron lecturas de sensores en vivo"
+
+#: src/components/SensorTable.tsx:92
+msgid "No miscellaneous sensors captured"
+msgstr "No se capturaron sensores misceláneos"
+
+#: src/components/SensorTable.tsx:88
+msgid "No power sensors found"
+msgstr "No se encontraron sensores de energía"
+
+#: src/app/Application.tsx:307
+msgid "No sensor backends are available on this system"
+msgstr "No hay backends de sensores disponibles en este sistema"
+
+#: src/components/SensorTable.tsx:76
+msgid "No temperature sensors detected"
+msgstr "No se detectaron sensores de temperatura"
+
+#: src/components/SensorTable.tsx:85
+msgid "No voltage inputs were reported by the available sensor backends."
+msgstr ""
+"Los backends de sensores disponibles no reportaron entradas de voltaje."
+
+#: src/components/SensorTable.tsx:84
+msgid "No voltage sensors reported"
+msgstr "No se informaron sensores de voltaje"
+
+#: src/app/Application.tsx:108
+msgid "Not updated yet"
+msgstr "Aún sin actualizar"
+
+#: src/app/Application.tsx:321
+msgid "On Debian or Ubuntu:"
+msgstr "En Debian o Ubuntu:"
+
+#: src/app/Application.tsx:317
+msgid "On Fedora, RHEL or CentOS:"
+msgstr "En Fedora, RHEL o CentOS:"
+
+#: src/app/Application.tsx:83
+msgid "Other"
+msgstr "Otros"
+
+#: src/app/Application.tsx:435
+msgid "Pause / resume"
+msgstr "Pausar / reanudar"
+
+#: src/app/Application.tsx:361
+msgid "Paused"
+msgstr "En pausa"
+
+#: src/components/SensorTable.tsx:198
+msgid "Peak power draw"
+msgstr "Consumo máximo"
+
+#: src/components/SensorTable.tsx:235 src/components/SensorTable.tsx:241
+msgid "Pin sensor"
+msgstr "Fijar sensor"
+
+#: src/components/SensorTable.tsx:233
+msgid "Pinned status"
+msgstr "Estado fijado"
+
+#: src/app/Application.tsx:77
+msgid "Power"
+msgstr "Energía"
+
+#: src/components/SensorTable.tsx:89
+msgid "Power metrics were not exposed for this host or backend."
+msgstr "No se expusieron métricas de energía para este host o backend."
+
+#: src/app/Application.tsx:292
+msgid "Retry with privileges"
+msgstr "Reintentar con privilegios"
+
+#: src/app/Application.tsx:310
+msgid "Run detection again"
+msgstr "Ejecutar la detección nuevamente"
+
+#: src/app/Application.tsx:434
+msgid "Search"
+msgstr "Buscar"
+
+#: src/components/SensorTable.tsx:261
+msgid "Sensor"
+msgstr "Sensor"
+
+#: src/app/Application.tsx:461
+msgid "Sensor category list"
+msgstr "Lista de categorías de sensores"
+
+#: src/app/Application.tsx:289
+msgid "Sensor data requires administrative privileges"
+msgstr "Los datos de sensores requieren privilegios administrativos"
+
+#: src/components/SensorSummary.tsx:30
+msgid "Sensor highlights"
+msgstr "Resumen de sensores"
+
+#: src/index.html:20 src/app/Application.tsx:390 src/manifest.json:0
 #: org.cockpit-project.sensors.metainfo.xml:5
-#: src/app.jsx:162
 msgid "Sensors"
 msgstr "Sensores"
 
+#: org.cockpit-project.sensors.metainfo.xml:6
 #: org.cockpit-project.sensors.metainfo.xml:8
 msgid "Sensors cockpit module"
 msgstr "Módulo de sensores para Cockpit"
 
-#: src/app.jsx:86
-msgid "lm-sensors not found, you want install it ?"
-msgstr "No se encontró lm-sensors, ¿quieres instalarlo?"
+#: src/app/Application.tsx:379
+msgid "Sensors dashboard"
+msgstr "Panel de sensores"
 
-#: src/app.jsx:95
-msgid "this version of lm-sensors don't suport output sensors data!"
-msgstr "¡Esta versión de lm-sensors no admite la salida de datos de sensores!"
+#: src/components/SensorTable.tsx:93
+msgid "Sensors outside the dedicated categories are not reporting data."
+msgstr ""
+"Los sensores fuera de las categorías dedicadas no están reportando datos."
 
-#: src/app.jsx:130
-msgid "lm-sensors has a bug that converts all data to fahrenheit, including voltage, fans and etc."
-msgstr "lm-sensors tiene un error que convierte todos los datos a Fahrenheit, incluyendo voltaje, ventiladores y más."
+#: src/app/Application.tsx:84
+msgid ""
+"Sensors that do not match temperature, fan, voltage or power categories."
+msgstr "Sensores que no encajan en las categorías de temperatura, ventiladores, voltaje o energía."
 
-#: src/app.jsx:200
-msgid "Show temperature in Fahrenheit"
-msgstr "Mostrar temperatura en Fahrenheit"
+#: src/app/Application.tsx:436
+msgid "Switch °C / °F"
+msgstr "Cambiar °C / °F"
 
-#: src/app.jsx:206
-msgid "Expand all cards"
-msgstr "Expandir todas las tarjetas"
+#: src/app/Application.tsx:78
+msgid "System and package power draw reported by RAPL interfaces."
+msgstr "Consumo del sistema y del paquete reportado por las interfaces RAPL."
 
-#: src/app.jsx:174
-msgid "Install"
-msgstr "Instalar"
-
-#: src/app/Application.tsx
+#: src/app/Application.tsx:59
 msgid "Temperatures"
 msgstr "Temperaturas"
 
-#: src/app/Application.tsx
-msgid "View and compare the temperature sensors reported by the system."
-msgstr "Visualiza y compara los sensores de temperatura reportados por el sistema."
+#: src/components/SensorTable.tsx:81
+msgid "The hardware monitoring stack did not expose any fan speed sensors."
+msgstr ""
+"La pila de monitorización de hardware no expuso sensores de velocidad de "
+"ventiladores."
 
-#: src/app/Application.tsx
-msgid "Fans"
-msgstr "Ventiladores"
+#: src/app/Application.tsx:335
+msgid ""
+"This environment may not expose physical sensors. Virtual machines commonly "
+"omit hardware monitoring interfaces."
+msgstr ""
+"Este entorno puede no exponer sensores físicos. Las máquinas virtuales "
+"suelen omitir interfaces de monitorización de hardware."
 
-#: src/app/Application.tsx
-msgid "Monitor the status of installed fans without reloading the page."
-msgstr "Supervisa el estado de los ventiladores instalados sin recargar la página."
+#: src/app/Application.tsx:362
+msgid "Threshold exceeded"
+msgstr "Umbral superado"
 
-#: src/app/Application.tsx
-msgid "Voltages"
-msgstr "Voltajes"
+#: src/app/Application.tsx:437
+msgid "Toggle table / cards"
+msgstr "Alternar tabla / tarjetas"
 
-#: src/app/Application.tsx
-msgid "Review available voltage readings for power supplies and system buses."
-msgstr "Revisa las lecturas de voltaje disponibles para fuentes de alimentación y buses del sistema."
-
-#: src/app/Application.tsx
-msgid "Other sensors"
-msgstr "Otros sensores"
-
-#: src/app/Application.tsx
-msgid "Sensor category list"
-msgstr "Lista de categorías de sensores"
-
-#: src/app/Application.tsx
-msgid "Sensor data requires administrative privileges"
-msgstr "Los datos de sensores requieren privilegios administrativos"
-
-#: src/app/Application.tsx
-msgid "Retry with privileges"
-msgstr "Reintentar con privilegios"
-
-#: src/app/Application.tsx
-msgid "Cockpit could not read sensor data without elevated permissions. Retry the operation to trigger a privilege prompt."
-msgstr "Cockpit no pudo leer los datos de sensores sin permisos elevados. Reintenta la operación para mostrar la solicitud de privilegios."
-
-#: src/app/Application.tsx
-msgid "No sensor backends are available on this system"
-msgstr "No hay backends de sensores disponibles en este sistema"
-
-#: src/app/Application.tsx
-msgid "Install the recommended packages below and rerun the detection to expose hardware monitoring sensors."
-msgstr "Instala los paquetes recomendados a continuación y ejecuta nuevamente la detección para exponer los sensores de monitorización de hardware."
-
-#: src/app/Application.tsx
-msgid "Copy command"
-msgstr "Copiar comando"
-
-#: src/app/Application.tsx
-#: src/components/SensorTable.tsx
-msgid "Copied"
-msgstr "Copiado"
-
-#: src/app/Application.tsx
-msgid "Run detection again"
-msgstr "Ejecutar la detección nuevamente"
-
-#: src/app/Application.tsx
-msgid "No live sensor readings were reported"
-msgstr "No se informaron lecturas de sensores en vivo"
-
-#: src/app/Application.tsx
-msgid "This environment may not expose physical sensors. Virtual machines commonly omit hardware monitoring interfaces."
-msgstr "Este entorno puede no exponer sensores físicos. Las máquinas virtuales suelen omitir interfaces de monitorización de hardware."
-
-#: src/app/Application.tsx
-msgid "Unable to collect sensor data"
-msgstr "No se pudieron recopilar datos de sensores"
-
-#: src/app/Application.tsx
-msgid "An unexpected error prevented the Sensors page from retrieving live metrics."
-msgstr "Un error inesperado impidió que la página de Sensores obtuviera métricas en vivo."
-
-#: src/app/Application.tsx
+#: src/app/Application.tsx:347
 msgid "Try again"
 msgstr "Intentar de nuevo"
 
-#: src/app/Application.tsx
-msgid "Data sources"
-msgstr "Fuentes de datos"
+#: src/components/CsvModalViewer.tsx:73
+msgid "Try download again"
+msgstr "Reintentar descarga"
 
-#: src/app/Application.tsx
-msgid "(active)"
-msgstr "(activo)"
+#: src/app/Application.tsx:341
+msgid "Unable to collect sensor data"
+msgstr "No se pudieron recopilar datos de sensores"
 
-#: src/app/Application.tsx
-msgid "Loading sensor data..."
-msgstr "Cargando datos de sensores..."
-
-#: src/components/SensorTable.tsx
-msgid "No temperature sensors detected"
-msgstr "No se detectaron sensores de temperatura"
-
-#: src/components/SensorTable.tsx
-msgid "Cockpit did not receive any temperature readings for this system."
-msgstr "Cockpit no recibió lecturas de temperatura para este sistema."
-
-#: src/components/SensorTable.tsx
-msgid "No fan telemetry available"
-msgstr "No hay telemetría de ventiladores disponible"
-
-#: src/components/SensorTable.tsx
-msgid "The hardware monitoring stack did not expose any fan speed sensors."
-msgstr "La pila de monitorización de hardware no expuso sensores de velocidad de ventiladores."
-
-#: src/components/SensorTable.tsx
-msgid "No voltage sensors reported"
-msgstr "No se informaron sensores de voltaje"
-
-#: src/components/SensorTable.tsx
-msgid "No voltage inputs were reported by the available sensor backends."
-msgstr "Los backends de sensores disponibles no reportaron entradas de voltaje."
-
-#: src/components/SensorTable.tsx
-msgid "No power sensors found"
-msgstr "No se encontraron sensores de energía"
-
-#: src/components/SensorTable.tsx
-msgid "Power metrics were not exposed for this host or backend."
-msgstr "No se expusieron métricas de energía para este host o backend."
-
-#: src/components/SensorTable.tsx
-msgid "No miscellaneous sensors captured"
-msgstr "No se capturaron sensores misceláneos"
-
-#: src/components/SensorTable.tsx
-msgid "Sensors outside the dedicated categories are not reporting data."
-msgstr "Los sensores fuera de las categorías dedicadas no están reportando datos."
-
-#: src/components/SensorTable.tsx
-msgid "Sensor table controls"
-msgstr "Controles de la tabla de sensores"
-
-#: src/components/SensorTable.tsx
-msgid "Refresh interval"
-msgstr "Intervalo de actualización"
-
-#: src/components/SensorTable.tsx
-msgid "Refresh interval selector"
-msgstr "Selector de intervalo de actualización"
-
-#: src/components/SensorTable.tsx
-msgid "Every 10 seconds"
-msgstr "Cada 10 segundos"
-
-#: src/components/SensorTable.tsx
-msgid "Every 5 seconds"
-msgstr "Cada 5 segundos"
-
-#: src/components/SensorTable.tsx
-msgid "Every 2 seconds"
-msgstr "Cada 2 segundos"
-
-#: src/components/SensorTable.tsx
-msgid "Temperature unit"
-msgstr "Unidad de temperatura"
-
-#: src/components/SensorTable.tsx
-msgid "Temperature unit selector"
-msgstr "Selector de unidad de temperatura"
-
-#: src/components/SensorTable.tsx
-msgid "Degrees Celsius (°C)"
-msgstr "Grados Celsius (°C)"
-
-#: src/components/SensorTable.tsx
-msgid "Degrees Fahrenheit (°F)"
-msgstr "Grados Fahrenheit (°F)"
-
-#: src/components/SensorTable.tsx
-msgid "Download session history as CSV"
-msgstr "Descargar el historial de la sesión como CSV"
-
-#: src/components/SensorTable.tsx
-#: src/app/Application.tsx
-msgid "Export CSV"
-msgstr "Exportar CSV"
-
-#: src/components/SensorTable.tsx
-msgid "Sensor readings"
-msgstr "Lecturas de sensores"
-
-#: src/components/SensorTable.tsx
-msgid "Pinned status"
-msgstr "Estado fijado"
-
-#: src/components/SensorTable.tsx
-msgid "Pin sensor"
-msgstr "Fijar sensor"
-
-#: src/components/SensorTable.tsx
+#: src/components/SensorTable.tsx:235 src/components/SensorTable.tsx:241
 msgid "Unpin sensor"
 msgstr "Quitar fijación del sensor"
 
-#: src/components/SensorTable.tsx
-msgid "Chip"
-msgstr "Chip"
+#: src/app/Application.tsx:115
+msgid "Updated $0h ago"
+msgstr "Actualizado hace $0h"
 
-#: src/components/SensorTable.tsx
-msgid "Sensor"
-msgstr "Sensor"
+#: src/app/Application.tsx:114
+msgid "Updated $0m ago"
+msgstr "Actualizado hace $0m"
 
-#: src/components/SensorTable.tsx
-msgid "Input"
-msgstr "Entrada"
+#: src/app/Application.tsx:113
+msgid "Updated $0s ago"
+msgstr "Actualizado hace $0s"
 
-#: src/components/SensorTable.tsx
-msgid "Session min/avg/max"
-msgstr "Mín/Prom/Máx de la sesión"
+#: src/app/Application.tsx:112
+msgid "Updated just now"
+msgstr "Actualizado justo ahora"
 
-#: src/components/SensorTable.tsx
-msgid "Trend"
-msgstr "Tendencia"
+#: src/app/Application.tsx:72
+msgid "Voltage readings exposed by power supplies and on-board rails."
+msgstr "Lecturas de voltaje expuestas por las fuentes de alimentación y las líneas de la placa."
 
-#: src/components/SensorTable.tsx
-msgid "Source"
-msgstr "Fuente"
+#: src/app/Application.tsx:71
+msgid "Voltages"
+msgstr "Voltajes"
 
-#: src/components/SensorTable.tsx
-msgid "Downloads may be restricted by the browser sandbox. Copy the CSV below or try to download it."
-msgstr "Las descargas pueden estar restringidas por el sandbox del navegador. Copia el CSV de abajo o intenta descargarlo."
+#: src/app/Application.tsx:428
+msgid "active"
+msgstr "activo"
 
-#: src/components/SensorTable.tsx
-msgid "Copy"
-msgstr "Copiar"
+#: src/components/SensorTable.tsx:454
+msgid "samples"
+msgstr "muestras"
 
-#: src/components/SensorTable.tsx
-msgid "Try download"
-msgstr "Intentar descarga"
+#: src/components/SensorTable.tsx:615
+msgid "seconds"
+msgstr "segundos"
 
-#: src/components/SensorTable.tsx
-msgid "Close"
-msgstr "Cerrar"
+#~ msgid "Cockpit Sensors"
+#~ msgstr "Sensores de Cockpit"
+
+#~ msgid "lm-sensors not found, you want install it ?"
+#~ msgstr "No se encontró lm-sensors, ¿quieres instalarlo?"
+
+#~ msgid "this version of lm-sensors don't suport output sensors data!"
+#~ msgstr ""
+#~ "¡Esta versión de lm-sensors no admite la salida de datos de sensores!"
+
+#~ msgid ""
+#~ "lm-sensors has a bug that converts all data to fahrenheit, including "
+#~ "voltage, fans and etc."
+#~ msgstr ""
+#~ "lm-sensors tiene un error que convierte todos los datos a Fahrenheit, "
+#~ "incluyendo voltaje, ventiladores y más."
+
+#~ msgid "Show temperature in Fahrenheit"
+#~ msgstr "Mostrar temperatura en Fahrenheit"
+
+#~ msgid "Expand all cards"
+#~ msgstr "Expandir todas las tarjetas"
+
+#~ msgid "Install"
+#~ msgstr "Instalar"
+
+#~ msgid "Sensor table controls"
+#~ msgstr "Controles de la tabla de sensores"
+
+#~ msgid "Refresh interval"
+#~ msgstr "Intervalo de actualización"
+
+#~ msgid "Refresh interval selector"
+#~ msgstr "Selector de intervalo de actualización"
+
+#~ msgid "Every 10 seconds"
+#~ msgstr "Cada 10 segundos"
+
+#~ msgid "Every 2 seconds"
+#~ msgstr "Cada 2 segundos"
+
+#~ msgid "Temperature unit"
+#~ msgstr "Unidad de temperatura"
+
+#~ msgid "Temperature unit selector"
+#~ msgstr "Selector de unidad de temperatura"
+
+#~ msgid "Degrees Celsius (°C)"
+#~ msgstr "Grados Celsius (°C)"
+
+#~ msgid "Degrees Fahrenheit (°F)"
+#~ msgstr "Grados Fahrenheit (°F)"
+
+#~ msgid "Download session history as CSV"
+#~ msgstr "Descargar el historial de la sesión como CSV"
+
+#~ msgid "Input"
+#~ msgstr "Entrada"
+
+#~ msgid "Session min/avg/max"
+#~ msgstr "Mín/Prom/Máx de la sesión"
+
+#~ msgid "Trend"
+#~ msgstr "Tendencia"
+
+#~ msgid "Source"
+#~ msgstr "Fuente"
+
+#~ msgid ""
+#~ "Downloads may be restricted by the browser sandbox. Copy the CSV below or "
+#~ "try to download it."
+#~ msgstr ""
+#~ "Las descargas pueden estar restringidas por el sandbox del navegador. "
+#~ "Copia el CSV de abajo o intenta descargarlo."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sensors 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-09 16:09+0100\n"
+"POT-Creation-Date: 2026-07-09 20:56-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Cristopfer Luis <ocristopfer@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -14,211 +14,426 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1\n"
 
-#: src/index.html:20
-msgid "Cockpit Sensors"
-msgstr "Sensores para Cockpit"
+#: src/app/Application.tsx:393
+msgid "$0 readings"
+msgstr "$0 leituras"
 
-#: src/manifest.json:8 
-#: org.cockpit-project.sensors.metainfo.xml:5 
-#: src/app.jsx:162
+#: src/components/SensorTable.tsx:100
+msgid "10s"
+msgstr "10s"
+
+#: src/components/SensorTable.tsx:98
+msgid "2s"
+msgstr "2s"
+
+#: src/components/SensorTable.tsx:99
+msgid "5s"
+msgstr "5s"
+
+#: src/components/SensorTable.tsx:187
+msgid "Active fans"
+msgstr "Ventoinhas ativas"
+
+#: src/components/SensorTable.tsx:197
+msgid "Active power sensors"
+msgstr "Sensores de energia ativos"
+
+#: src/components/SensorTable.tsx:202
+msgid "Active sensors"
+msgstr "Sensores ativos"
+
+#: src/components/SensorTable.tsx:182
+msgid "Active temperature sensors"
+msgstr "Sensores de temperatura ativos"
+
+#: src/components/SensorTable.tsx:192
+msgid "Active voltage rails"
+msgstr "Trilhas de tensão ativas"
+
+#: src/app/Application.tsx:364
+msgid "All sensors healthy"
+msgstr "Todos os sensores saudáveis"
+
+#: src/app/Application.tsx:343
+msgid ""
+"An unexpected error prevented the Sensors page from retrieving live metrics."
+msgstr ""
+"Um erro inesperado impediu a página de Sensores de obter métricas em tempo "
+"real."
+
+#: src/app/Application.tsx:363
+msgid "Approaching threshold"
+msgstr "Aproximando-se do limite"
+
+#: src/components/SensorTable.tsx:189
+msgid "Average fan speed"
+msgstr "Velocidade média das ventoinhas"
+
+#: src/components/SensorTable.tsx:199
+msgid "Average power draw"
+msgstr "Consumo médio de energia"
+
+#: src/components/SensorTable.tsx:184
+msgid "Average temperature"
+msgstr "Temperatura média"
+
+#: src/components/SensorTable.tsx:204
+msgid "Average value"
+msgstr "Valor médio"
+
+#: src/components/SensorTable.tsx:194
+msgid "Average voltage"
+msgstr "Tensão média"
+
+#: src/components/CsvModalViewer.tsx:62
+msgid "CSV content"
+msgstr "Conteúdo CSV"
+
+#: src/components/SensorTable.tsx:251
+msgid "Chip"
+msgstr "Chip"
+
+#: src/components/CsvModalViewer.tsx:80
+msgid "Close"
+msgstr "Fechar"
+
+#: src/app/Application.tsx:297
+msgid ""
+"Cockpit could not read sensor data without elevated permissions. Retry the "
+"operation to trigger a privilege prompt."
+msgstr ""
+"O Cockpit não conseguiu ler os dados dos sensores sem permissões elevadas. "
+"Tente novamente para acionar o pedido de privilégios."
+
+#: src/components/SensorTable.tsx:77
+msgid "Cockpit did not receive any temperature readings for this system."
+msgstr "O Cockpit não recebeu nenhuma leitura de temperatura deste sistema."
+
+#: src/app/Application.tsx:60
+msgid "Compare temperature sensors reported by the host system."
+msgstr "Compare os sensores de temperatura relatados pelo sistema."
+
+#: src/app/Application.tsx:318 src/app/Application.tsx:322
+msgid "Copied"
+msgstr "Copiado"
+
+#: src/components/CsvModalViewer.tsx:69
+msgid "Copy"
+msgstr "Copiar"
+
+#: src/app/Application.tsx:318 src/app/Application.tsx:322
+msgid "Copy command"
+msgstr "Copiar comando"
+
+#: src/components/CsvModalViewer.tsx:67
+msgid "Copy to clipboard"
+msgstr "Copiar para a área de transferência"
+
+#: src/components/SensorTable.tsx:264
+msgid "Current"
+msgstr "Atual"
+
+#: src/app/Application.tsx:420
+msgid "Data sources"
+msgstr "Fontes de dados"
+
+#: src/components/CsvModalViewer.tsx:75
+msgid "Download"
+msgstr "Baixar"
+
+#: src/app/Application.tsx:358
+msgid "Error"
+msgstr "Erro"
+
+#: src/components/CsvModalViewer.tsx:50
+msgid "Export CSV"
+msgstr "Exportar CSV"
+
+#: src/app/Application.tsx:65
+msgid "Fans"
+msgstr "Ventoinhas"
+
+#: src/components/SensorTable.tsx:188
+msgid "Fastest fan"
+msgstr "Ventoinha mais rápida"
+
+#: src/components/SensorTable.tsx:203
+msgid "Highest value"
+msgstr "Maior valor"
+
+#: src/components/SensorTable.tsx:193
+msgid "Highest voltage"
+msgstr "Maior tensão"
+
+#: src/components/SensorTable.tsx:183
+msgid "Hottest reading"
+msgstr "Leitura mais quente"
+
+#: src/app/Application.tsx:394
+msgid "Idle"
+msgstr "Ocioso"
+
+#: src/app/Application.tsx:315
+msgid ""
+"Install the recommended packages below and rerun the detection to expose "
+"hardware monitoring sensors."
+msgstr ""
+"Instale os pacotes recomendados abaixo e execute a detecção novamente para "
+"expor os sensores de monitoramento de hardware."
+
+#: src/app/Application.tsx:398
+msgid "Live hardware telemetry: temperature, fans, voltages and power."
+msgstr "Telemetria de hardware ao vivo: temperatura, ventoinhas, tensões e energia."
+
+#: src/app/Application.tsx:495 src/app/Application.tsx:498
+msgid "Loading sensor data..."
+msgstr "Carregando dados dos sensores..."
+
+#: src/app/Application.tsx:66
+msgid "Monitor cooling without reloading the page."
+msgstr "Monitore a refrigeração sem recarregar a página."
+
+#: src/app/Application.tsx:357
+msgid "Needs privileges"
+msgstr "Requer privilégios"
+
+#: src/app/Application.tsx:359
+msgid "No backends"
+msgstr "Sem backends"
+
+#: src/app/Application.tsx:360
+msgid "No data"
+msgstr "Sem dados"
+
+#: src/components/SensorTable.tsx:80
+msgid "No fan telemetry available"
+msgstr "Nenhuma telemetria de ventoinha disponível"
+
+#: src/app/Application.tsx:332
+msgid "No live sensor readings were reported"
+msgstr "Nenhuma leitura ao vivo de sensores foi informada"
+
+#: src/components/SensorTable.tsx:92
+msgid "No miscellaneous sensors captured"
+msgstr "Nenhum sensor diverso capturado"
+
+#: src/components/SensorTable.tsx:88
+msgid "No power sensors found"
+msgstr "Nenhum sensor de energia encontrado"
+
+#: src/app/Application.tsx:307
+msgid "No sensor backends are available on this system"
+msgstr "Nenhum backend de sensor está disponível neste sistema"
+
+#: src/components/SensorTable.tsx:76
+msgid "No temperature sensors detected"
+msgstr "Nenhum sensor de temperatura detectado"
+
+#: src/components/SensorTable.tsx:85
+msgid "No voltage inputs were reported by the available sensor backends."
+msgstr "Os backends de sensores disponíveis não relataram entradas de tensão."
+
+#: src/components/SensorTable.tsx:84
+msgid "No voltage sensors reported"
+msgstr "Nenhum sensor de tensão relatado"
+
+#: src/app/Application.tsx:108
+msgid "Not updated yet"
+msgstr "Ainda não atualizado"
+
+#: src/app/Application.tsx:321
+msgid "On Debian or Ubuntu:"
+msgstr "No Debian ou Ubuntu:"
+
+#: src/app/Application.tsx:317
+msgid "On Fedora, RHEL or CentOS:"
+msgstr "No Fedora, RHEL ou CentOS:"
+
+#: src/app/Application.tsx:83
+msgid "Other"
+msgstr "Outros"
+
+#: src/app/Application.tsx:435
+msgid "Pause / resume"
+msgstr "Pausar / retomar"
+
+#: src/app/Application.tsx:361
+msgid "Paused"
+msgstr "Pausado"
+
+#: src/components/SensorTable.tsx:198
+msgid "Peak power draw"
+msgstr "Pico de consumo de energia"
+
+#: src/components/SensorTable.tsx:235 src/components/SensorTable.tsx:241
+msgid "Pin sensor"
+msgstr "Fixar sensor"
+
+#: src/components/SensorTable.tsx:233
+msgid "Pinned status"
+msgstr "Estado de fixação"
+
+#: src/app/Application.tsx:77
+msgid "Power"
+msgstr "Energia"
+
+#: src/components/SensorTable.tsx:89
+msgid "Power metrics were not exposed for this host or backend."
+msgstr "Métricas de energia não foram expostas para este host ou backend."
+
+#: src/app/Application.tsx:292
+msgid "Retry with privileges"
+msgstr "Tentar novamente com privilégios"
+
+#: src/app/Application.tsx:310
+msgid "Run detection again"
+msgstr "Executar a detecção novamente"
+
+#: src/app/Application.tsx:434
+msgid "Search"
+msgstr "Pesquisar"
+
+#: src/components/SensorTable.tsx:261
+msgid "Sensor"
+msgstr "Sensor"
+
+#: src/app/Application.tsx:461
+msgid "Sensor category list"
+msgstr "Lista de categorias de sensores"
+
+#: src/app/Application.tsx:289
+msgid "Sensor data requires administrative privileges"
+msgstr "Os dados de sensores exigem privilégios administrativos"
+
+#: src/components/SensorSummary.tsx:30
+msgid "Sensor highlights"
+msgstr "Destaques dos sensores"
+
+#: src/index.html:20 src/app/Application.tsx:390 src/manifest.json:0
+#: org.cockpit-project.sensors.metainfo.xml:5
 msgid "Sensors"
 msgstr "Sensores"
 
+#: org.cockpit-project.sensors.metainfo.xml:6
 #: org.cockpit-project.sensors.metainfo.xml:8
 msgid "Sensors cockpit module"
 msgstr "Sensores do lm-sensors para o cockpit"
 
-#: src/app.jsx:86
-msgid "lm-sensors not found, you want install it ?"
-msgstr "Não foi encontrado o lm-sensors, deseja instala-lo?"
+#: src/app/Application.tsx:379
+msgid "Sensors dashboard"
+msgstr "Painel de sensores"
 
-#: src/app.jsx:95
-msgid "this version of lm-sensors don't suport output sensors data!"
-msgstr "Essa versão do lm-sensors não tem suporte para saida de dados!"
+#: src/components/SensorTable.tsx:93
+msgid "Sensors outside the dedicated categories are not reporting data."
+msgstr "Sensores fora das categorias dedicadas não estão relatando dados."
 
-#: src/app.jsx:130
-msgid "lm-sensors has a bug that converts all data to fahrenheit, including voltage, fans and etc."
-msgstr "lm-sensors tem um problema aonde ele converte todos os dados para fahrenheit, incluindo voltage, vetoinhas e etc."
+#: src/app/Application.tsx:84
+msgid ""
+"Sensors that do not match temperature, fan, voltage or power categories."
+msgstr "Sensores que não se encaixam nas categorias de temperatura, ventoinha, tensão ou energia."
 
-#: src/app.jsx:200
-msgid "Show temperature in Fahrenheit"
-msgstr "Exibir temperatus em Fahrenheit"
+#: src/app/Application.tsx:436
+msgid "Switch °C / °F"
+msgstr "Alternar °C / °F"
 
-#: src/app.jsx:206
-msgid "Expand all cards"
-msgstr "Expandir todos os cards"
+#: src/app/Application.tsx:78
+msgid "System and package power draw reported by RAPL interfaces."
+msgstr "Consumo de energia do sistema e do pacote relatado pelas interfaces RAPL."
 
-#: src/app.jsx:174
-msgid "Install"
-msgstr "Instalar"
+#: src/app/Application.tsx:59
+msgid "Temperatures"
+msgstr "Temperaturas"
 
-#: src/app/Application.tsx
-msgid "Sensor data requires administrative privileges"
-msgstr "Os dados de sensores exigem privilégios administrativos"
+#: src/components/SensorTable.tsx:81
+msgid "The hardware monitoring stack did not expose any fan speed sensors."
+msgstr "A pilha de monitoramento de hardware não expôs sensores de velocidade de ventoinha."
 
-#: src/app/Application.tsx
-msgid "Retry with privileges"
-msgstr "Tentar novamente com privilégios"
+#: src/app/Application.tsx:335
+msgid ""
+"This environment may not expose physical sensors. Virtual machines commonly "
+"omit hardware monitoring interfaces."
+msgstr ""
+"Este ambiente pode não expor sensores físicos. Máquinas virtuais normalmente "
+"omitem interfaces de monitoramento de hardware."
 
-#: src/app/Application.tsx
-msgid "Cockpit could not read sensor data without elevated permissions. Retry the operation to trigger a privilege prompt."
-msgstr "O Cockpit não conseguiu ler os dados dos sensores sem permissões elevadas. Tente novamente para acionar o pedido de privilégios."
+#: src/app/Application.tsx:362
+msgid "Threshold exceeded"
+msgstr "Limite excedido"
 
-#: src/app/Application.tsx
-msgid "No sensor backends are available on this system"
-msgstr "Nenhum backend de sensor está disponível neste sistema"
+#: src/app/Application.tsx:437
+msgid "Toggle table / cards"
+msgstr "Alternar tabela / cartões"
 
-#: src/app/Application.tsx
-msgid "Install the recommended packages below and rerun the detection to expose hardware monitoring sensors."
-msgstr "Instale os pacotes recomendados abaixo e execute a detecção novamente para expor os sensores de monitoramento de hardware."
-
-#: src/app/Application.tsx
-msgid "Copy command"
-msgstr "Copiar comando"
-
-#: src/app/Application.tsx
-msgid "Copied"
-msgstr "Copiado"
-
-#: src/app/Application.tsx
-msgid "Run detection again"
-msgstr "Executar a detecção novamente"
-
-#: src/app/Application.tsx
-msgid "No live sensor readings were reported"
-msgstr "Nenhuma leitura ao vivo de sensores foi informada"
-
-#: src/app/Application.tsx
-msgid "This environment may not expose physical sensors. Virtual machines commonly omit hardware monitoring interfaces."
-msgstr "Este ambiente pode não expor sensores físicos. Máquinas virtuais normalmente omitem interfaces de monitoramento de hardware."
-
-#: src/app/Application.tsx
-msgid "Unable to collect sensor data"
-msgstr "Não foi possível coletar dados dos sensores"
-
-#: src/app/Application.tsx
-msgid "An unexpected error prevented the Sensors page from retrieving live metrics."
-msgstr "Um erro inesperado impediu a página de Sensores de obter métricas em tempo real."
-
-#: src/app/Application.tsx
+#: src/app/Application.tsx:347
 msgid "Try again"
 msgstr "Tentar novamente"
 
-#: src/app/Application.tsx
-msgid "Data sources"
-msgstr "Fontes de dados"
+#: src/components/CsvModalViewer.tsx:73
+msgid "Try download again"
+msgstr "Tentar baixar novamente"
 
-#: src/app/Application.tsx
-msgid "(active)"
-msgstr "(ativo)"
-#: src/components/SensorTable.tsx
-msgid "No temperature sensors detected"
-msgstr ""
+#: src/app/Application.tsx:341
+msgid "Unable to collect sensor data"
+msgstr "Não foi possível coletar dados dos sensores"
 
-#: src/components/SensorTable.tsx
-msgid "Cockpit did not receive any temperature readings for this system."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No fan telemetry available"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "The hardware monitoring stack did not expose any fan speed sensors."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No voltage sensors reported"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No voltage inputs were reported by the available sensor backends."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No power sensors found"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Power metrics were not exposed for this host or backend."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "No miscellaneous sensors captured"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Sensors outside the dedicated categories are not reporting data."
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Sensor table controls"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Refresh interval"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Refresh interval selector"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Every 10 seconds"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Every 5 seconds"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Every 2 seconds"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Temperature unit"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Temperature unit selector"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Degrees Celsius (°C)"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Degrees Fahrenheit (°F)"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Download session history as CSV"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Export CSV"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Pinned status"
-msgstr ""
-
-#: src/components/SensorTable.tsx
-msgid "Pin sensor"
-msgstr ""
-
-#: src/components/SensorTable.tsx
+#: src/components/SensorTable.tsx:235 src/components/SensorTable.tsx:241
 msgid "Unpin sensor"
-msgstr ""
+msgstr "Desafixar sensor"
 
-#: src/components/SensorTable.tsx
-msgid "Session min/avg/max"
-msgstr ""
+#: src/app/Application.tsx:115
+msgid "Updated $0h ago"
+msgstr "Atualizado há $0h"
 
-#: src/components/SensorTable.tsx
-msgid "Trend"
-msgstr ""
+#: src/app/Application.tsx:114
+msgid "Updated $0m ago"
+msgstr "Atualizado há $0m"
 
-#: src/components/SensorTable.tsx
-msgid "Source"
-msgstr ""
+#: src/app/Application.tsx:113
+msgid "Updated $0s ago"
+msgstr "Atualizado há $0s"
+
+#: src/app/Application.tsx:112
+msgid "Updated just now"
+msgstr "Atualizado agora mesmo"
+
+#: src/app/Application.tsx:72
+msgid "Voltage readings exposed by power supplies and on-board rails."
+msgstr "Leituras de tensão expostas por fontes de alimentação e trilhas da placa."
+
+#: src/app/Application.tsx:71
+msgid "Voltages"
+msgstr "Tensões"
+
+#: src/app/Application.tsx:428
+msgid "active"
+msgstr "ativo"
+
+#: src/components/SensorTable.tsx:454
+msgid "samples"
+msgstr "amostras"
+
+#: src/components/SensorTable.tsx:615
+msgid "seconds"
+msgstr "segundos"
+
+#~ msgid "lm-sensors not found, you want install it ?"
+#~ msgstr "Não foi encontrado o lm-sensors, deseja instala-lo?"
+
+#~ msgid "this version of lm-sensors don't suport output sensors data!"
+#~ msgstr "Essa versão do lm-sensors não tem suporte para saida de dados!"
+
+#~ msgid ""
+#~ "lm-sensors has a bug that converts all data to fahrenheit, including "
+#~ "voltage, fans and etc."
+#~ msgstr ""
+#~ "lm-sensors tem um problema aonde ele converte todos os dados para "
+#~ "fahrenheit, incluindo voltage, vetoinhas e etc."
+
+#~ msgid "Show temperature in Fahrenheit"
+#~ msgstr "Exibir temperatus em Fahrenheit"
+
+#~ msgid "Expand all cards"
+#~ msgstr "Expandir todos os cards"
+
+#~ msgid "Install"
+#~ msgstr "Instalar"

--- a/src/__mocks__/@patternfly/react-core.ts
+++ b/src/__mocks__/@patternfly/react-core.ts
@@ -50,11 +50,45 @@ export const CodeBlockCode = ({ children, ...props }: ComponentProps) =>
     React.createElement('code', props, children);
 export const Content = createElement('section');
 
-export const Label = ({ children, ...props }: ComponentProps & { isCompact?: boolean; color?: string }) => {
-    const { isCompact, color, ...rest } = props;
+export const Label = ({
+    children,
+    ...props
+}: ComponentProps & { isCompact?: boolean; color?: string; status?: string }) => {
+    const { isCompact, color, status, ...rest } = props;
     void isCompact;
     void color;
+    return React.createElement('span', { ...rest, 'data-status': status }, children);
+};
+
+export const Badge = ({ children, ...props }: ComponentProps & { isRead?: boolean }) => {
+    const { isRead, ...rest } = props;
+    void isRead;
     return React.createElement('span', rest, children);
+};
+
+export const Card = ({ children, ...props }: ComponentProps & { isCompact?: boolean }) => {
+    const { isCompact, ...rest } = props;
+    void isCompact;
+    return React.createElement('article', rest, children);
+};
+
+export const CardBody = createElement('div');
+
+export const Gallery = ({
+    children,
+    ...props
+}: ComponentProps & { hasGutter?: boolean; minWidths?: Record<string, string> }) => {
+    const { hasGutter, minWidths, ...rest } = props;
+    void hasGutter;
+    void minWidths;
+    return React.createElement('section', rest, children);
+};
+
+export const Skeleton = ({ ...props }: ComponentProps & { height?: string; screenreaderText?: string }) => {
+    const { height, screenreaderText, ...rest } = props;
+    void height;
+    void screenreaderText;
+    return React.createElement('div', { ...rest, 'data-skeleton': true });
 };
 
 export const LabelGroup = ({
@@ -166,6 +200,15 @@ export const EmptyStateIcon = ({ icon }: { icon?: React.ElementType }) => {
 
 export const Toolbar = createElement('div');
 export const ToolbarContent = createElement('div');
+export const ToolbarToggleGroup = ({
+    children,
+    ...props
+}: ComponentProps & { toggleIcon?: React.ReactNode; breakpoint?: string }) => {
+    const { toggleIcon, breakpoint, ...rest } = props;
+    void toggleIcon;
+    void breakpoint;
+    return React.createElement('div', rest, children);
+};
 export const ToolbarGroup = ({ children, ...props }: ComponentProps) => {
     const { align, alignItems, variant, ...rest } = props;
     void align;

--- a/src/__mocks__/@patternfly/react-icons.ts
+++ b/src/__mocks__/@patternfly/react-icons.ts
@@ -13,6 +13,7 @@ export const StarIcon = createIcon('StarIcon');
 export const SearchIcon = createIcon('SearchIcon');
 export const BarsIcon = createIcon('BarsIcon');
 export const ExclamationCircleIcon = createIcon('ExclamationCircleIcon');
+export const FilterIcon = createIcon('FilterIcon');
 export const ListIcon = createIcon('ListIcon');
 export const GripVerticalIcon = createIcon('GripVerticalIcon');
 export const ThIcon = createIcon('ThIcon');

--- a/src/__tests__/useSensors.helpers.test.ts
+++ b/src/__tests__/useSensors.helpers.test.ts
@@ -32,6 +32,66 @@ describe('useSensors helpers', () => {
         expect(result[0]).toMatchObject({ provider: 'hwmon', value: 50 });
     });
 
+    it('drops nvme-cli samples when the kernel nvme hwmon driver covers the drives', () => {
+        const samplesByProvider = new Map<string, SensorSample[]>();
+
+        samplesByProvider.set('hwmon', [
+            {
+                kind: 'temp',
+                id: 'hwmon3:temp1',
+                label: 'Composite',
+                value: 38,
+                chipId: 'hwmon3',
+                chipLabel: 'nvme',
+                chipName: 'nvme',
+            },
+        ]);
+
+        samplesByProvider.set('nvme', [
+            {
+                kind: 'temp',
+                id: '/dev/nvme0:temperature',
+                label: 'Samsung SSD',
+                value: 38,
+                chipId: '/dev/nvme0',
+                chipName: 'Samsung SSD',
+            },
+        ]);
+
+        const result = aggregateSamples(samplesByProvider);
+        expect(result).toHaveLength(1);
+        expect(result[0].provider).toBe('hwmon');
+    });
+
+    it('keeps nvme-cli samples when hwmon does not expose the drives', () => {
+        const samplesByProvider = new Map<string, SensorSample[]>();
+
+        samplesByProvider.set('hwmon', [
+            {
+                kind: 'temp',
+                id: 'hwmon0:temp1',
+                label: 'Core 0',
+                value: 50,
+                chipId: 'hwmon0',
+                chipName: 'coretemp',
+            },
+        ]);
+
+        samplesByProvider.set('nvme', [
+            {
+                kind: 'temp',
+                id: '/dev/nvme0:temperature',
+                label: 'Samsung SSD',
+                value: 38,
+                chipId: '/dev/nvme0',
+                chipName: 'Samsung SSD',
+            },
+        ]);
+
+        const result = aggregateSamples(samplesByProvider);
+        expect(result).toHaveLength(2);
+    });
+
     it('converts samples into sensor data grouped by chip and category', () => {
         const samples: SampleWithProvider[] = [
             {

--- a/src/app.scss
+++ b/src/app.scss
@@ -82,46 +82,6 @@ body {
     flex-wrap: wrap;
 }
 
-.sensor-app__status-pill {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding-block: 0.25rem;
-    padding-inline: 0.6rem;
-    border-radius: 999px;
-    font-size: var(--pf-t--global--font--size--sm, 0.875rem);
-    font-weight: 600;
-    line-height: 1;
-    border: 1px solid var(--sensor-border);
-    background: var(--sensor-bg-surface);
-}
-
-.sensor-app__status-pill--normal { color: var(--sensor-sparkline-normal); }
-.sensor-app__status-pill--warning { color: var(--sensor-sparkline-warning); border-color: currentcolor; }
-.sensor-app__status-pill--danger { color: var(--sensor-sparkline-danger); border-color: currentcolor; }
-
-.sensor-app__status-pill::before {
-    content: "";
-    inline-size: 0.5rem;
-    block-size: 0.5rem;
-    border-radius: 50%;
-    background: currentcolor;
-    box-shadow: 0 0 0 0.25rem color-mix(in srgb, currentcolor 18%, transparent);
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .sensor-app__status-pill::before {
-        animation: sensor-pulse 1.8s ease-in-out infinite;
-    }
-
-    .sensor-app__status-pill--idle::before { animation: none; }
-}
-
-@keyframes sensor-pulse {
-    0%, 100% { transform: scale(1); opacity: 1; }
-    50% { transform: scale(0.85); opacity: 0.6; }
-}
-
 .sensor-app__updated {
     color: var(--sensor-text-muted);
     font-size: var(--pf-t--global--font--size--sm, 0.875rem);
@@ -176,48 +136,20 @@ body {
     gap: 0.4rem;
 }
 
-.sensor-tab__count {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-inline-size: 1.25rem;
-    padding-inline: 0.35rem;
-    block-size: 1.25rem;
-    border-radius: 999px;
-    font-size: 0.7rem;
-    font-weight: 600;
-    background: var(--sensor-bg-hover);
-    color: var(--sensor-text-muted);
-    line-height: 1;
-}
-
+/* PF Badge provides the pill; only the severity accent is ours. */
 .sensor-tab__count[data-state="warning"] {
     background: color-mix(in srgb, var(--sensor-sparkline-warning) 18%, transparent);
-    color: var(--sensor-sparkline-warning);
+    color: var(--pf-t--global--text--color--status--warning--default);
 }
 
 .sensor-tab__count[data-state="danger"] {
     background: color-mix(in srgb, var(--sensor-sparkline-danger) 18%, transparent);
-    color: var(--sensor-sparkline-danger);
+    color: var(--pf-t--global--text--color--status--danger--default);
 }
 
-/* ---------- Summary KPIs ---------- */
-.sensor-summary {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: var(--pf-t--global--spacer--md, 0.75rem);
-}
-
-.sensor-summary__card {
-    border: 1px solid var(--sensor-border);
-    border-radius: var(--sensor-card-radius);
-    padding: var(--pf-t--global--spacer--md, 0.75rem) var(--pf-t--global--spacer--lg, 1rem);
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    background: var(--sensor-bg-surface);
-}
-
+/* ---------- Summary KPIs ----------
+   Layout and card surface come from PF Gallery/Card; only the inner
+   typography and severity accents live here. */
 .sensor-summary__label {
     color: var(--sensor-text-muted);
     font-size: var(--pf-t--global--font--size--xs, 0.75rem);
@@ -247,17 +179,6 @@ body {
 .sensor-summary__card--danger .sensor-summary__value { color: var(--sensor-sparkline-danger); }
 
 /* ---------- Toolbar ---------- */
-.sensor-toolbar {
-    --pf-v6-c-toolbar--PaddingInlineStart: 0;
-    --pf-v6-c-toolbar--PaddingInlineEnd: 0;
-    --pf-v6-c-toolbar--PaddingBlockEnd: 0;
-    --pf-v6-c-toolbar--PaddingBlockStart: 0;
-    border: 1px solid var(--sensor-border);
-    border-radius: var(--sensor-card-radius);
-    padding: var(--pf-t--global--spacer--sm, 0.5rem) var(--pf-t--global--spacer--md, 0.75rem);
-    background: var(--sensor-bg-surface);
-}
-
 .sensor-toolbar__search {
     min-inline-size: 220px;
 }
@@ -524,30 +445,6 @@ body {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
     gap: var(--pf-t--global--spacer--md, 0.75rem);
-}
-
-.sensor-skeleton__card {
-    border: 1px solid var(--sensor-border);
-    border-radius: var(--sensor-card-radius);
-    padding: var(--pf-t--global--spacer--md, 0.75rem);
-    block-size: 130px;
-    background:
-        linear-gradient(90deg,
-            var(--sensor-bg-surface) 0%,
-            var(--sensor-bg-hover) 50%,
-            var(--sensor-bg-surface) 100%);
-    background-size: 200% 100%;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .sensor-skeleton__card {
-        animation: sensor-shimmer 1.4s linear infinite;
-    }
-}
-
-@keyframes sensor-shimmer {
-    0% { background-position: 100% 0; }
-    100% { background-position: -100% 0; }
 }
 
 /* ---------- Modal ---------- */

--- a/src/app/Application.tsx
+++ b/src/app/Application.tsx
@@ -22,12 +22,14 @@ import {
     Alert,
     AlertActionLink,
     AlertVariant,
+    Badge,
     Button,
     ClipboardCopy,
     Label,
     Page,
     PageGroup,
     PageSection,
+    Skeleton,
     Tab,
     TabTitleText,
     Tabs,
@@ -397,12 +399,18 @@ export const Application: React.FC = () => {
                             </p>
                         </div>
                         <div className="sensor-app__meta">
-                            <span
-                                className={`sensor-app__status-pill sensor-app__status-pill--${pillVariant}${isPaused ? ' sensor-app__status-pill--idle' : ''}`}
-                                role="status"
-                                aria-live="polite"
-                            >
-                                {statusPillLabel}
+                            <span role="status">
+                                {isPaused && pillVariant === 'normal'
+                                    ? <Label color="grey">{statusPillLabel}</Label>
+                                    : (
+                                        <Label
+                                            status={pillVariant === 'danger'
+                                                ? 'danger'
+                                                : pillVariant === 'warning' ? 'warning' : 'success'}
+                                        >
+                                            {statusPillLabel}
+                                        </Label>
+                                    )}
                             </span>
                             <LastUpdated timestamp={lastUpdate} />
                         </div>
@@ -466,12 +474,13 @@ export const Application: React.FC = () => {
                                     <TabTitleText>
                                         <span className="sensor-tab__title">
                                             {tab.title}
-                                            <span
+                                            <Badge
+                                                isRead={state === 'normal'}
                                                 className="sensor-tab__count"
                                                 data-state={state}
                                             >
                                                 {count}
-                                            </span>
+                                            </Badge>
                                         </span>
                                     </TabTitleText>
                                 }
@@ -486,9 +495,9 @@ export const Application: React.FC = () => {
                                         aria-label={_('Loading sensor data...')}
                                         role="status"
                                     >
-                                        <div className="sensor-skeleton__card" />
-                                        <div className="sensor-skeleton__card" />
-                                        <div className="sensor-skeleton__card" />
+                                        <Skeleton height="130px" screenreaderText={_('Loading sensor data...')} />
+                                        <Skeleton height="130px" />
+                                        <Skeleton height="130px" />
                                     </div>
                                 )}
                                 {!isLoading && (

--- a/src/components/SensorSummary.tsx
+++ b/src/components/SensorSummary.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Card, CardBody, Gallery } from '@patternfly/react-core';
 
 import { _ } from '../utils/cockpit';
 import type { ThresholdState } from '../utils/thresholds';
@@ -22,27 +23,32 @@ export const SensorSummary: React.FC<SensorSummaryProps> = ({ stats, 'aria-label
     }
 
     return (
-        <section
+        <Gallery
+            hasGutter
+            minWidths={{ default: '220px' }}
             className="sensor-summary"
             aria-label={ariaLabel ?? _('Sensor highlights')}
         >
             {stats.map(stat => {
                 const severity = stat.severity ?? 'normal';
                 return (
-                    <div
+                    <Card
+                        isCompact
                         key={stat.label}
-                        className={`sensor-summary__card sensor-summary__card--${severity}`}
+                        className={`sensor-summary__card--${severity}`}
                         data-testid="sensor-summary-card"
                     >
-                        <div className="sensor-summary__label">{stat.label}</div>
-                        <div className="sensor-summary__value">
-                            <span>{stat.value}</span>
-                            {stat.unit && <span className="sensor-summary__unit">{stat.unit}</span>}
-                        </div>
-                        {stat.hint && <div className="sensor-summary__hint">{stat.hint}</div>}
-                    </div>
+                        <CardBody>
+                            <div className="sensor-summary__label">{stat.label}</div>
+                            <div className="sensor-summary__value">
+                                <span>{stat.value}</span>
+                                {stat.unit && <span className="sensor-summary__unit">{stat.unit}</span>}
+                            </div>
+                            {stat.hint && <div className="sensor-summary__hint">{stat.hint}</div>}
+                        </CardBody>
+                    </Card>
                 );
             })}
-        </section>
+        </Gallery>
     );
 };

--- a/src/components/SensorTable.tsx
+++ b/src/components/SensorTable.tsx
@@ -11,12 +11,14 @@ import {
     ToolbarContent,
     ToolbarGroup,
     ToolbarItem,
+    ToolbarToggleGroup,
     Tooltip,
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import {
     DownloadIcon,
     ExclamationCircleIcon,
+    FilterIcon,
     GripVerticalIcon,
     ListIcon,
     OutlinedStarIcon,
@@ -576,66 +578,88 @@ export const SensorTable: React.FC<SensorTableProps> = ({
                         />
                     </ToolbarItem>
 
-                    {onViewModeChange && (
-                        <ToolbarItem>
-                            <ToggleGroup aria-label={_('Select view mode')}>
-                                <ToggleGroupItem
+                    <ToolbarToggleGroup toggleIcon={<FilterIcon />} breakpoint="md">
+                        {onViewModeChange && (
+                            <ToolbarItem>
+                                <ToggleGroup aria-label={_('Select view mode')}>
+                                    <ToggleGroupItem
                                     icon={<ListIcon />}
                                     aria-label={_('Show as table')}
                                     buttonId="sensor-view-table"
                                     isSelected={viewMode === 'table'}
                                     onChange={() => onViewModeChange('table')}
                                     text={_('Table')}
-                                />
-                                <ToggleGroupItem
+                                    />
+                                    <ToggleGroupItem
                                     icon={<GripVerticalIcon />}
                                     aria-label={_('Show as cards')}
                                     buttonId="sensor-view-cards"
                                     isSelected={viewMode === 'cards'}
                                     onChange={() => onViewModeChange('cards')}
                                     text={_('Cards')}
-                                />
-                            </ToggleGroup>
-                        </ToolbarItem>
-                    )}
+                                    />
+                                </ToggleGroup>
+                            </ToolbarItem>
+                        )}
 
-                    <ToolbarItem>
-                        <span className="sensor-toolbar__group-label">{_('Refresh')}</span>
-                        <ToggleGroup aria-label={_('Refresh interval')}>
-                            {SENSOR_REFRESH_OPTIONS.map(option => (
-                                <ToggleGroupItem
+                        <ToolbarItem>
+                            <span className="sensor-toolbar__group-label">{_('Refresh')}</span>
+                            <ToggleGroup aria-label={_('Refresh interval')}>
+                                {SENSOR_REFRESH_OPTIONS.map(option => (
+                                    <ToggleGroupItem
                                     key={option}
                                     text={REFRESH_LABELS[option] ?? `${option / 1000}s`}
                                     buttonId={`sensor-refresh-${option}`}
                                     isSelected={refreshMs === option}
                                     onChange={() => onRefreshChange(option)}
                                     aria-label={`${option / 1000} ${_('seconds')}`}
-                                />
-                            ))}
-                        </ToggleGroup>
-                    </ToolbarItem>
+                                    />
+                                ))}
+                            </ToggleGroup>
+                        </ToolbarItem>
 
-                    {category === 'temperature' && (
-                        <ToolbarItem>
-                            <span className="sensor-toolbar__group-label">{_('Unit')}</span>
-                            <ToggleGroup aria-label={_('Temperature unit')}>
-                                <ToggleGroupItem
+                        {category === 'temperature' && (
+                            <ToolbarItem>
+                                <span className="sensor-toolbar__group-label">{_('Unit')}</span>
+                                <ToggleGroup aria-label={_('Temperature unit')}>
+                                    <ToggleGroupItem
                                     text="°C"
                                     buttonId="sensor-unit-c"
                                     isSelected={unit === 'C'}
                                     onChange={() => onUnitChange('C')}
                                     aria-label={_('Celsius')}
-                                />
-                                <ToggleGroupItem
+                                    />
+                                    <ToggleGroupItem
                                     text="°F"
                                     buttonId="sensor-unit-f"
                                     isSelected={unit === 'F'}
                                     onChange={() => onUnitChange('F')}
                                     aria-label={_('Fahrenheit')}
-                                />
-                            </ToggleGroup>
-                        </ToolbarItem>
-                    )}
+                                    />
+                                </ToggleGroup>
+                            </ToolbarItem>
+                        )}
+
+                        {onDensityChange && (
+                            <ToolbarItem>
+                                <span className="sensor-toolbar__group-label">{_('Density')}</span>
+                                <ToggleGroup aria-label={_('Table density')}>
+                                    <ToggleGroupItem
+                                    text={_('Compact')}
+                                    buttonId="sensor-density-compact"
+                                    isSelected={density === 'compact'}
+                                    onChange={() => onDensityChange('compact')}
+                                    />
+                                    <ToggleGroupItem
+                                    text={_('Comfortable')}
+                                    buttonId="sensor-density-comfortable"
+                                    isSelected={density === 'comfortable'}
+                                    onChange={() => onDensityChange('comfortable')}
+                                    />
+                                </ToggleGroup>
+                            </ToolbarItem>
+                        )}
+                    </ToolbarToggleGroup>
 
                     {onPauseToggle && (
                         <ToolbarItem>
@@ -650,26 +674,6 @@ export const SensorTable: React.FC<SensorTableProps> = ({
                                     {isPaused ? _('Resume') : _('Pause')}
                                 </Button>
                             </Tooltip>
-                        </ToolbarItem>
-                    )}
-
-                    {onDensityChange && (
-                        <ToolbarItem visibility={{ default: 'hidden', md: 'visible' }}>
-                            <span className="sensor-toolbar__group-label">{_('Density')}</span>
-                            <ToggleGroup aria-label={_('Table density')}>
-                                <ToggleGroupItem
-                                    text={_('Compact')}
-                                    buttonId="sensor-density-compact"
-                                    isSelected={density === 'compact'}
-                                    onChange={() => onDensityChange('compact')}
-                                />
-                                <ToggleGroupItem
-                                    text={_('Comfortable')}
-                                    buttonId="sensor-density-comfortable"
-                                    isSelected={density === 'comfortable'}
-                                    onChange={() => onDensityChange('comfortable')}
-                                />
-                            </ToggleGroup>
                         </ToolbarItem>
                     )}
 

--- a/src/hooks/useSensors.ts
+++ b/src/hooks/useSensors.ts
@@ -45,7 +45,17 @@ const aggregateSamples = (samplesByProvider: Map<string, SensorSample[]>): Sampl
     const aggregated: SampleWithProvider[] = [];
     const seen = new Set<string>();
 
+    // The kernel nvme driver exposes drive temperatures through hwmon (chip
+    // name "nvme", with Composite/Sensor readings). When present, the
+    // nvme-cli provider would report every drive a second time.
+    const hwmonCoversNvme = (samplesByProvider.get('hwmon') ?? [])
+            .some(sample => sample.chipName === 'nvme');
+
     for (const providerName of AGGREGATION_ORDER) {
+        if (providerName === 'nvme' && hwmonCoversNvme) {
+            continue;
+        }
+
         const samples = samplesByProvider.get(providerName) ?? [];
         for (const sample of samples) {
             const dedupeKey = `${sample.kind}:${sample.id}`;

--- a/src/lib/providers/__tests__/cpufreq.test.ts
+++ b/src/lib/providers/__tests__/cpufreq.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { cpufreqProvider } from '../cpufreq';
+import type { SensorSample } from '../types';
+
+const FREQ_PATH = (core: number) => `/sys/devices/system/cpu/cpu${core}/cpufreq/scaling_cur_freq`;
+
+type OnChangeMock = Mock<(samples: SensorSample[]) => void>;
+
+const lastSamples = (onChange: OnChangeMock): SensorSample[] => {
+    const calls = onChange.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1][0];
+};
+
+describe('cpufreqProvider polling', () => {
+    let files: Map<string, string>;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        files = new Map([
+            [FREQ_PATH(0), '3500000\n'],
+            [FREQ_PATH(1), '2000000\n'],
+        ]);
+        Object.defineProperty(globalThis, 'cockpit', {
+            value: {
+                gettext: (message: string) => message,
+                file: (path: string) => ({
+                    read: () => Promise.resolve(files.get(path) ?? null),
+                    close: () => undefined,
+                }),
+            },
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('discovers consecutive cores and reports frequencies in MHz', async () => {
+        const onChange: OnChangeMock = vi.fn();
+        const stop = cpufreqProvider.start(onChange, { refreshIntervalMs: 1000 });
+
+        await vi.advanceTimersByTimeAsync(0);
+        const samples = lastSamples(onChange);
+        expect(samples).toHaveLength(2);
+        expect(samples[0].label).toBe('Core 0');
+        expect(samples[0].value).toBeCloseTo(3500);
+        expect(samples[1].value).toBeCloseTo(2000);
+        expect(samples[0].unit).toBe('MHz');
+
+        stop();
+    });
+
+    it('emits fresh frequencies on each interval and pauses on demand', async () => {
+        let paused = false;
+        const onChange: OnChangeMock = vi.fn();
+        const stop = cpufreqProvider.start(onChange, {
+            refreshIntervalMs: 1000,
+            isPaused: () => paused,
+        });
+
+        await vi.advanceTimersByTimeAsync(0);
+        files.set(FREQ_PATH(0), '4200000\n');
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(lastSamples(onChange)[0].value).toBeCloseTo(4200);
+
+        paused = true;
+        files.set(FREQ_PATH(0), '1000000\n');
+        await vi.advanceTimersByTimeAsync(3000);
+        expect(lastSamples(onChange)[0].value).toBeCloseTo(4200);
+
+        paused = false;
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(lastSamples(onChange)[0].value).toBeCloseTo(1000);
+
+        stop();
+    });
+});

--- a/src/lib/providers/__tests__/powercap.test.ts
+++ b/src/lib/providers/__tests__/powercap.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { powercapProvider } from '../powercap';
+import type { SensorSample } from '../types';
+
+const DOMAIN_PATH = '/sys/class/powercap/intel-rapl:0';
+
+type OnChangeMock = Mock<(samples: SensorSample[]) => void>;
+
+const lastSamples = (onChange: OnChangeMock): SensorSample[] => {
+    const calls = onChange.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1][0];
+};
+
+describe('powercapProvider polling', () => {
+    let files: Map<string, string>;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(1_000_000);
+        files = new Map([
+            [`${DOMAIN_PATH}/name`, 'package-0\n'],
+            [`${DOMAIN_PATH}/energy_uj`, '10000000\n'],
+            [`${DOMAIN_PATH}/max_energy_range_uj`, '262143328850\n'],
+        ]);
+        Object.defineProperty(globalThis, 'cockpit', {
+            value: {
+                gettext: (message: string) => message,
+                spawn: (command: string[] | string) => {
+                    const args = Array.isArray(command) ? command : [command];
+                    return Promise.resolve(args[0] === 'find' ? `${DOMAIN_PATH}\n` : '');
+                },
+                file: (path: string) => ({
+                    read: () => Promise.resolve(files.get(path) ?? null),
+                    close: () => undefined,
+                }),
+            },
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('derives watts from energy counter deltas between polls', async () => {
+        const onChange: OnChangeMock = vi.fn();
+        const stop = powercapProvider.start(onChange, { refreshIntervalMs: 1000 });
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        // 5 J consumed over 1 s → 5 W
+        files.set(`${DOMAIN_PATH}/energy_uj`, String(10_000_000 + 5_000_000));
+        await vi.advanceTimersByTimeAsync(1000);
+
+        const samples = lastSamples(onChange);
+        expect(samples).toHaveLength(1);
+        expect(samples[0].kind).toBe('power');
+        expect(samples[0].unit).toBe('W');
+        expect(samples[0].label).toBe('package-0');
+        expect(samples[0].value).toBeCloseTo(5, 1);
+
+        stop();
+    });
+
+    it('survives energy counter wrap-around using max_energy_range_uj', async () => {
+        const onChange: OnChangeMock = vi.fn();
+        const stop = powercapProvider.start(onChange, { refreshIntervalMs: 1000 });
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Counter wrapped: the new reading is below the previous one, so the
+        // real consumption is (new - last) + max_energy_range. The provider
+        // must apply the wrap correction instead of emitting a negative value.
+        files.set(`${DOMAIN_PATH}/energy_uj`, '1000000');
+        await vi.advanceTimersByTimeAsync(1000);
+
+        const samples = lastSamples(onChange);
+        expect(samples).toHaveLength(1);
+        expect(samples[0].value).toBeGreaterThan(0);
+
+        stop();
+    });
+});


### PR DESCRIPTION
i18n: the po template tools moved to pkg/lib/html2po|manifest2po in the pinned cockpit lib, so pot generation had been silently broken; fix the Makefile, regenerate the template and translate every remaining string in Spanish, German and Brazilian Portuguese (0 untranslated, 0 fuzzy in all three).

Tests: powercap gains coverage for its energy-delta and wrap-around logic, cpufreq for discovery/polling/pause, and useSensors for the new nvme dedupe — when the kernel nvme hwmon driver already exposes drive temperatures, the nvme-cli provider no longer duplicates every drive.

Design: the last hand-rolled widgets are gone — summary KPIs use PF Gallery/Card, the status pill is a PF status Label, tab counters are PF Badges and the loading state uses PF Skeleton; ~90 lines of custom CSS drop with them. The toolbar filter controls collapse behind a filter toggle on narrow screens (density is reachable on mobile now) and the toolbar loses its non-standard card framing.